### PR TITLE
Releasing new v3.0.2

### DIFF
--- a/.github/workflows/builder_0_1.yml
+++ b/.github/workflows/builder_0_1.yml
@@ -92,7 +92,7 @@ jobs:
           cp docs/base-gcc.md $HOME/README.md
           bash utils/SF_docs_deployer
         shell: bash
-        if: success() && github.event_name == 'push'
+        if: success() && github.event_name == 'release'
       - name: deploy
         run: bash utils/SF_deployer
         shell: bash
@@ -146,7 +146,7 @@ jobs:
           cp docs/cross-gcc.md $HOME/root/README.md
           bash utils/SF_docs_deployer
         shell: bash
-        if: success() && github.event_name == 'push'
+        if: success() && github.event_name == 'release'
       - name: deploy
         run: bash utils/SF_deployer
         shell: bash
@@ -200,7 +200,7 @@ jobs:
           cp docs/native-gcc.md $HOME/root/README.md
           bash utils/SF_docs_deployer
         shell: bash
-        if: success() && github.event_name == 'push'
+        if: success() && github.event_name == 'release'
       - name: deploy
         run: bash utils/SF_deployer
         shell: bash

--- a/.github/workflows/builder_0_1.yml
+++ b/.github/workflows/builder_0_1.yml
@@ -38,9 +38,8 @@ on:
     branches:
       - master
 
-
-
 env:
+  RPI_TYPE: 0-1
   CURL_VERSION: 7.68.0
   CCACHE_COMPRESS: 1
   CCACHE_DIR: $HOME/.ccache
@@ -48,13 +47,14 @@ env:
   PASSWORD_SFTP: ${{ secrets.PASSWORD_SFTP }}
 
 jobs:
-  builder-buster_0:
-    name: BASE GCC-8.3.0 32-bit Buster Pi[0-1]
+  builder-base:
+    name: Base GCC 32-bit Builder Pi[0-1]
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rpios_types: [stretch, buster]
     env:
-      GCC_VERSION: 8.3.0  
-      RPIOS_TYPE: buster 
-      RPI_TYPE: 0-1
+      RPIOS_TYPE: ${{ matrix.rpios_types }}
       COMPILER_TYPE: CROSS
       BASE: true
     steps:
@@ -80,7 +80,7 @@ jobs:
           source ~/.bashrc && echo $PATH
         if: success()
       - name: script
-        run: bash build-scripts/CI/CIBB_32b -g $GCC_VERSION -r $RPI_TYPE -o $RPIOS_TYPE
+        run: bash build-scripts/CI/CIBB_32b -r $RPI_TYPE -o $RPIOS_TYPE
         shell: bash
         if: success() && github.event_name == 'pull_request'
       - name: before_script
@@ -97,14 +97,18 @@ jobs:
         run: bash utils/SF_deployer
         shell: bash
         if: success() && github.event_name == 'release' && github.event.action == 'published'
-  builder-buster_1:
-    name: Cross GCC-9.3.0 32-bit Buster Pi[0-1]
-    needs: builder-buster_0
+
+  builder-cross:
+    name: Cross GCC 32-bit Builder Pi[0-1]
+    needs: builder-base
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        gcc_versions: [6.3.0, 8.3.0, 9.2.0, 9.3.0, 10.1.0]
+        rpios_types: [stretch, buster]
     env:
-      GCC_VERSION: 9.3.0  
-      RPIOS_TYPE: buster 
-      RPI_TYPE: 0-1
+      GCC_VERSION: ${{ matrix.gcc_versions }}  
+      RPIOS_TYPE: ${{ matrix.rpios_types }} 
       COMPILER_TYPE: CROSS
     steps:
       - uses: actions/checkout@v2
@@ -147,55 +151,18 @@ jobs:
         run: bash utils/SF_deployer
         shell: bash
         if: success() && github.event_name == 'release' && github.event.action == 'published'
-  builder-buster_1_1:
-    name: Cross GCC-8.3.0 32-bit Buster Pi[0-1]
-    needs: builder-buster_0
+
+  builder-native:
+    name: Native GCC 32-bit Builder Pi[0-1]
+    needs: [builder-base, builder-cross]
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        gcc_versions: [9.3.0, 10.1.0]
+        rpios_types: [stretch, buster]
     env:
-      GCC_VERSION: 8.3.0  
-      RPIOS_TYPE: buster 
-      RPI_TYPE: 0-1
-      COMPILER_TYPE: CROSS
-    steps:
-      - uses: actions/checkout@v2
-      - name: before_install
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -qq dos2unix -y
-          dos2unix build-scripts/CI/CICTB_32b 
-          chmod +x build-scripts/CI/CICTB_32b 
-          dos2unix patches/curl_stfp_patcher
-          chmod +x patches/curl_stfp_patcher
-          dos2unix utils/SF_deployer
-          chmod +x utils/SF_deployer
-        if: success()
-      - name: install
-        run: |
-          sudo apt-get -y install -qq gcc g++ gperf flex texinfo pigz gawk gfortran texinfo bison libncurses-dev ccache autoconf automake build-essential libssh2-1-dev openssl libcurl3 unzip wget
-          sudo /usr/sbin/update-ccache-symlinks
-          echo 'export PATH="/usr/lib/ccache:$PATH"' | tee -a ~/.bashrc
-          source ~/.bashrc && echo $PATH
-        if: success()
-      - name: script
-        run: bash build-scripts/CI/CICTB_32b -g $GCC_VERSION -r $RPI_TYPE -o $RPIOS_TYPE
-        shell: bash
-        if: success()
-      - name: before_script
-        run: bash patches/curl_stfp_patcher
-        shell: bash
-        if: success()
-      - name: deploy
-        run: bash utils/SF_deployer
-        shell: bash
-        if: success() && github.event_name == 'release' && github.event.action == 'published'
-  builder-buster_2:
-    name: Native GCC-9.3.0 32-bit Buster Pi[0-1]
-    needs: [builder-buster_0, builder-buster_1]
-    runs-on: ubuntu-latest
-    env:
-      GCC_VERSION: 9.3.0  
-      RPIOS_TYPE: buster 
-      RPI_TYPE: 0-1
+      GCC_VERSION: ${{ matrix.gcc_versions }}  
+      RPIOS_TYPE: ${{ matrix.rpios_types }}  
       COMPILER_TYPE: NATIVE
     steps:
       - uses: actions/checkout@v2
@@ -234,171 +201,6 @@ jobs:
           bash utils/SF_docs_deployer
         shell: bash
         if: success() && github.event_name == 'push'
-      - name: deploy
-        run: bash utils/SF_deployer
-        shell: bash
-        if: success() && github.event_name == 'release' && github.event.action == 'published'
-
-  builder-stretch_0:
-    name: BASE GCC-6.3.0 32-bit Stretch Pi[0-1]
-    runs-on: ubuntu-latest
-    env:
-      GCC_VERSION: 6.3.0  
-      RPIOS_TYPE: stretch 
-      RPI_TYPE: 0-1
-      COMPILER_TYPE: CROSS
-      BASE: true
-    steps:
-      - uses: actions/checkout@v2
-      - name: before_install
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -qq dos2unix -y
-          dos2unix build-scripts/CI/CIBB_32b 
-          chmod +x build-scripts/CI/CIBB_32b 
-          dos2unix patches/curl_stfp_patcher
-          chmod +x patches/curl_stfp_patcher
-          dos2unix utils/SF_deployer
-          chmod +x utils/SF_deployer
-        if: success()
-      - name: install
-        run: |
-          sudo apt-get -y install -qq gcc g++ gperf flex texinfo pigz gawk gfortran texinfo bison libncurses-dev ccache autoconf automake build-essential libssh2-1-dev openssl libcurl3 unzip wget
-          sudo /usr/sbin/update-ccache-symlinks
-          echo 'export PATH="/usr/lib/ccache:$PATH"' | tee -a ~/.bashrc
-          source ~/.bashrc && echo $PATH
-        if: success()
-      - name: script
-        run: bash build-scripts/CI/CIBB_32b -g $GCC_VERSION -r $RPI_TYPE -o $RPIOS_TYPE
-        shell: bash
-        if: success() && github.event_name == 'pull_request'
-      - name: before_script
-        run: bash patches/curl_stfp_patcher
-        shell: bash
-        if: success()
-      - name: deploy
-        run: bash utils/SF_deployer
-        shell: bash
-        if: success() && github.event_name == 'release' && github.event.action == 'published'
-  builder-stretch_1:
-    name: Cross GCC-9.3.0 32-bit Stretch Pi[0-1]
-    needs: builder-stretch_0
-    runs-on: ubuntu-latest
-    env:
-      GCC_VERSION: 9.3.0  
-      RPIOS_TYPE: stretch 
-      RPI_TYPE: 0-1
-      COMPILER_TYPE: CROSS
-    steps:
-      - uses: actions/checkout@v2
-      - name: before_install
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -qq dos2unix -y
-          dos2unix build-scripts/CI/CICTB_32b 
-          chmod +x build-scripts/CI/CICTB_32b 
-          dos2unix patches/curl_stfp_patcher
-          chmod +x patches/curl_stfp_patcher
-          dos2unix utils/SF_deployer
-          chmod +x utils/SF_deployer
-        if: success()
-      - name: install
-        run: |
-          sudo apt-get -y install -qq gcc g++ gperf flex texinfo pigz gawk gfortran texinfo bison libncurses-dev ccache autoconf automake build-essential libssh2-1-dev openssl libcurl3 unzip wget
-          sudo /usr/sbin/update-ccache-symlinks
-          echo 'export PATH="/usr/lib/ccache:$PATH"' | tee -a ~/.bashrc
-          source ~/.bashrc && echo $PATH
-        if: success()
-      - name: script
-        run: bash build-scripts/CI/CICTB_32b -g $GCC_VERSION -r $RPI_TYPE -o $RPIOS_TYPE
-        shell: bash
-        if: success()
-      - name: before_script
-        run: bash patches/curl_stfp_patcher
-        shell: bash
-        if: success()
-      - name: deploy
-        run: bash utils/SF_deployer
-        shell: bash
-        if: success() && github.event_name == 'release' && github.event.action == 'published'
-  builder-stretch_1_1:
-    name: Cross GCC-6.3.0 32-bit Stretch Pi[0-1]
-    needs: builder-stretch_0
-    runs-on: ubuntu-latest
-    env:
-      GCC_VERSION: 6.3.0  
-      RPIOS_TYPE: stretch 
-      RPI_TYPE: 0-1
-      COMPILER_TYPE: CROSS
-    steps:
-      - uses: actions/checkout@v2
-      - name: before_install
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -qq dos2unix -y
-          dos2unix build-scripts/CI/CICTB_32b 
-          chmod +x build-scripts/CI/CICTB_32b 
-          dos2unix patches/curl_stfp_patcher
-          chmod +x patches/curl_stfp_patcher
-          dos2unix utils/SF_deployer
-          chmod +x utils/SF_deployer
-        if: success()
-      - name: install
-        run: |
-          sudo apt-get -y install -qq gcc g++ gperf flex texinfo pigz gawk gfortran texinfo bison libncurses-dev ccache autoconf automake build-essential libssh2-1-dev openssl libcurl3 unzip wget
-          sudo /usr/sbin/update-ccache-symlinks
-          echo 'export PATH="/usr/lib/ccache:$PATH"' | tee -a ~/.bashrc
-          source ~/.bashrc && echo $PATH
-        if: success()
-      - name: script
-        run: bash build-scripts/CI/CICTB_32b -g $GCC_VERSION -r $RPI_TYPE -o $RPIOS_TYPE
-        shell: bash
-        if: success()
-      - name: before_script
-        run: bash patches/curl_stfp_patcher
-        shell: bash
-        if: success()
-      - name: deploy
-        run: bash utils/SF_deployer
-        shell: bash
-        if: success() && github.event_name == 'release' && github.event.action == 'published'
-  builder-stretch_2:
-    name: Native GCC-9.3.0 32-bit Stretch Pi[0-1]
-    needs: [builder-stretch_0, builder-stretch_1]
-    runs-on: ubuntu-latest
-    env:
-      GCC_VERSION: 9.3.0  
-      RPIOS_TYPE: stretch 
-      RPI_TYPE: 0-1 
-      COMPILER_TYPE: NATIVE
-    steps:
-      - uses: actions/checkout@v2
-      - name: before_install
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -qq dos2unix -y
-          dos2unix build-scripts/CI/CINTB_32b 
-          chmod +x build-scripts/CI/CINTB_32b 
-          dos2unix patches/curl_stfp_patcher
-          chmod +x patches/curl_stfp_patcher
-          dos2unix utils/SF_deployer
-          chmod +x utils/SF_deployer
-        if: success()
-      - name: install
-        run: |
-          sudo apt-get -y install -qq gcc g++ gperf flex texinfo pigz gawk gfortran texinfo bison libncurses-dev ccache autoconf automake build-essential libssh2-1-dev openssl libcurl3 unzip wget
-          sudo /usr/sbin/update-ccache-symlinks
-          echo 'export PATH="/usr/lib/ccache:$PATH"' | tee -a ~/.bashrc
-          source ~/.bashrc && echo $PATH
-        if: success()
-      - name: script
-        run: bash build-scripts/CI/CINTB_32b -g $GCC_VERSION -r $RPI_TYPE -o $RPIOS_TYPE
-        shell: bash
-        if: success()
-      - name: before_script
-        run: bash patches/curl_stfp_patcher
-        shell: bash
-        if: success()
       - name: deploy
         run: bash utils/SF_deployer
         shell: bash

--- a/.github/workflows/builder_2_3.yml
+++ b/.github/workflows/builder_2_3.yml
@@ -137,13 +137,13 @@ jobs:
           cp docs/cross-gcc-buster.md $HOME/README.md
           bash utils/SF_docs_deployer
         shell: bash
-        if: success() && github.event_name == 'push' && ${{ matrix.rpios_types }} == "buster"
+        if: success() && github.event_name == 'release' && ${{ matrix.rpios_types }} == "buster"
       - name: after_success_stretch
         run: |
           cp docs/cross-gcc-stretch.md $HOME/README.md
           bash utils/SF_docs_deployer
         shell: bash
-        if: success() && github.event_name == 'push' && ${{ matrix.rpios_types }} == "stretch"
+        if: success() && github.event_name == 'release' && ${{ matrix.rpios_types }} == "stretch"
       - name: deploy
         run: bash utils/SF_deployer
         shell: bash

--- a/.github/workflows/builder_2_3.yml
+++ b/.github/workflows/builder_2_3.yml
@@ -38,8 +38,8 @@ on:
     branches:
       - master
 
-
 env:
+  RPI_TYPE: 2-3
   CURL_VERSION: 7.68.0
   CCACHE_COMPRESS: 1
   CCACHE_DIR: $HOME/.ccache
@@ -47,13 +47,14 @@ env:
   PASSWORD_SFTP: ${{ secrets.PASSWORD_SFTP }}
 
 jobs:
-  builder-buster_0:
-    name: BASE GCC-8.3.0 32-bit Buster Pi[2-3]
+  builder-base:
+    name: Base GCC 32-bit Builder Pi[2-3]
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rpios_types: [stretch, buster]
     env:
-      GCC_VERSION: 8.3.0  
-      RPIOS_TYPE: buster 
-      RPI_TYPE: 2-3
+      RPIOS_TYPE: ${{ matrix.rpios_types }}
       COMPILER_TYPE: CROSS
       BASE: true
     steps:
@@ -77,140 +78,9 @@ jobs:
           source ~/.bashrc && echo $PATH
         if: success()
       - name: script
-        run: bash build-scripts/CI/CIBB_32b -g $GCC_VERSION -r $RPI_TYPE -o $RPIOS_TYPE
+        run: bash build-scripts/CI/CIBB_32b -r $RPI_TYPE -o $RPIOS_TYPE
         shell: bash
         if: success() && github.event_name == 'pull_request'
-      - name: before_script
-        run: bash patches/curl_stfp_patcher
-        shell: bash
-        if: success()
-      - name: deploy
-        run: bash utils/SF_deployer
-        shell: bash
-        if: success() && github.event_name == 'release' && github.event.action == 'published'
-  builder-buster_1:
-    name: Cross GCC-9.3.0 32-bit Buster Pi[2-3]
-    needs: builder-buster_0
-    runs-on: ubuntu-latest
-    env:
-      GCC_VERSION: 9.3.0  
-      RPIOS_TYPE: buster 
-      RPI_TYPE: 2-3
-      COMPILER_TYPE: CROSS
-    steps:
-      - uses: actions/checkout@v2
-      - name: before_install
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -qq dos2unix -y
-          dos2unix build-scripts/CI/CICTB_32b 
-          chmod +x build-scripts/CI/CICTB_32b 
-          dos2unix patches/curl_stfp_patcher
-          chmod +x patches/curl_stfp_patcher
-          dos2unix utils/SF_deployer
-          chmod +x utils/SF_deployer
-          dos2unix utils/SF_docs_deployer
-          chmod +x utils/SF_docs_deployer
-        if: success()
-      - name: install
-        run: |
-          sudo apt-get -y install -qq gcc g++ gperf flex texinfo pigz gawk gfortran texinfo bison libncurses-dev ccache autoconf automake build-essential libssh2-1-dev openssl libcurl3 unzip wget
-          sudo /usr/sbin/update-ccache-symlinks
-          echo 'export PATH="/usr/lib/ccache:$PATH"' | tee -a ~/.bashrc
-          source ~/.bashrc && echo $PATH
-        if: success()
-      - name: script
-        run: bash build-scripts/CI/CICTB_32b -g $GCC_VERSION -r $RPI_TYPE -o $RPIOS_TYPE
-        shell: bash
-        if: success()
-      - name: before_script
-        run: bash patches/curl_stfp_patcher
-        shell: bash
-        if: success()
-      - name: after_success
-        run: |
-          cp docs/cross-gcc-buster.md $HOME/README.md
-          bash utils/SF_docs_deployer
-        shell: bash
-        if: success() && github.event_name == 'push'
-      - name: deploy
-        run: bash utils/SF_deployer
-        shell: bash
-        if: success() && github.event_name == 'release' && github.event.action == 'published'
-  builder-buster_1_1:
-    name: Cross GCC-8.3.0 32-bit Buster Pi[2-3]
-    needs: builder-buster_0
-    runs-on: ubuntu-latest
-    env:
-      GCC_VERSION: 8.3.0  
-      RPIOS_TYPE: buster 
-      RPI_TYPE: 2-3
-      COMPILER_TYPE: CROSS
-    steps:
-      - uses: actions/checkout@v2
-      - name: before_install
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -qq dos2unix -y
-          dos2unix build-scripts/CI/CICTB_32b 
-          chmod +x build-scripts/CI/CICTB_32b 
-          dos2unix patches/curl_stfp_patcher
-          chmod +x patches/curl_stfp_patcher
-          dos2unix utils/SF_deployer
-          chmod +x utils/SF_deployer
-        if: success()
-      - name: install
-        run: |
-          sudo apt-get -y install -qq gcc g++ gperf flex texinfo pigz gawk gfortran texinfo bison libncurses-dev ccache autoconf automake build-essential libssh2-1-dev openssl libcurl3 unzip wget
-          sudo /usr/sbin/update-ccache-symlinks
-          echo 'export PATH="/usr/lib/ccache:$PATH"' | tee -a ~/.bashrc
-          source ~/.bashrc && echo $PATH
-        if: success()
-      - name: script
-        run: bash build-scripts/CI/CICTB_32b -g $GCC_VERSION -r $RPI_TYPE -o $RPIOS_TYPE
-        shell: bash
-        if: success()
-      - name: before_script
-        run: bash patches/curl_stfp_patcher
-        shell: bash
-        if: success()
-      - name: deploy
-        run: bash utils/SF_deployer
-        shell: bash
-        if: success() && github.event_name == 'release' && github.event.action == 'published'
-  builder-buster_2:
-    name: Native GCC-9.3.0 32-bit Buster Pi[2-3]
-    needs: [builder-buster_0, builder-buster_1]
-    runs-on: ubuntu-latest
-    env:
-      GCC_VERSION: 9.3.0  
-      RPIOS_TYPE: buster 
-      RPI_TYPE: 2-3 
-      COMPILER_TYPE: NATIVE
-    steps:
-      - uses: actions/checkout@v2
-      - name: before_install
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -qq dos2unix -y
-          dos2unix build-scripts/CI/CINTB_32b 
-          chmod +x build-scripts/CI/CINTB_32b 
-          dos2unix patches/curl_stfp_patcher
-          chmod +x patches/curl_stfp_patcher
-          dos2unix utils/SF_deployer
-          chmod +x utils/SF_deployer
-        if: success()
-      - name: install
-        run: |
-          sudo apt-get -y install -qq gcc g++ gperf flex texinfo pigz gawk gfortran texinfo bison libncurses-dev ccache autoconf automake build-essential libssh2-1-dev openssl libcurl3 unzip wget
-          sudo /usr/sbin/update-ccache-symlinks
-          echo 'export PATH="/usr/lib/ccache:$PATH"' | tee -a ~/.bashrc
-          source ~/.bashrc && echo $PATH
-        if: success()
-      - name: script
-        run: bash build-scripts/CI/CINTB_32b -g $GCC_VERSION -r $RPI_TYPE -o $RPIOS_TYPE
-        shell: bash
-        if: success()
       - name: before_script
         run: bash patches/curl_stfp_patcher
         shell: bash
@@ -220,55 +90,17 @@ jobs:
         shell: bash
         if: success() && github.event_name == 'release' && github.event.action == 'published'
 
-  builder-stretch_0:
-    name: BASE GCC-6.3.0 32-bit Stretch Pi[2-3]
+  builder-cross:
+    name: Cross GCC 32-bit Builder Pi[2-3]
+    needs: builder-base
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        gcc_versions: [6.3.0, 8.3.0, 9.2.0, 9.3.0, 10.1.0]
+        rpios_types: [stretch, buster]
     env:
-      GCC_VERSION: 6.3.0  
-      RPIOS_TYPE: stretch 
-      RPI_TYPE: 2-3
-      COMPILER_TYPE: CROSS
-      BASE: true
-    steps:
-      - uses: actions/checkout@v2
-      - name: before_install
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -qq dos2unix -y
-          dos2unix build-scripts/CI/CIBB_32b 
-          chmod +x build-scripts/CI/CIBB_32b 
-          dos2unix patches/curl_stfp_patcher
-          chmod +x patches/curl_stfp_patcher
-          dos2unix utils/SF_deployer
-          chmod +x utils/SF_deployer
-        if: success()
-      - name: install
-        run: |
-          sudo apt-get -y install -qq gcc g++ gperf flex texinfo pigz gawk gfortran texinfo bison libncurses-dev ccache autoconf automake build-essential libssh2-1-dev openssl libcurl3 unzip wget
-          sudo /usr/sbin/update-ccache-symlinks
-          echo 'export PATH="/usr/lib/ccache:$PATH"' | tee -a ~/.bashrc
-          source ~/.bashrc && echo $PATH
-        if: success()
-      - name: script
-        run: bash build-scripts/CI/CIBB_32b -g $GCC_VERSION -r $RPI_TYPE -o $RPIOS_TYPE
-        shell: bash
-        if: success() && github.event_name == 'pull_request'
-      - name: before_script
-        run: bash patches/curl_stfp_patcher
-        shell: bash
-        if: success()
-      - name: deploy
-        run: bash utils/SF_deployer
-        shell: bash
-        if: success() && github.event_name == 'release' && github.event.action == 'published'
-  builder-stretch_1:
-    name: Cross GCC-9.3.0 32-bit Stretch Pi[2-3]
-    needs: builder-stretch_0
-    runs-on: ubuntu-latest
-    env:
-      GCC_VERSION: 9.3.0  
-      RPIOS_TYPE: stretch 
-      RPI_TYPE: 2-3 
+      GCC_VERSION: ${{ matrix.gcc_versions }}  
+      RPIOS_TYPE: ${{ matrix.rpios_types }} 
       COMPILER_TYPE: CROSS
     steps:
       - uses: actions/checkout@v2
@@ -300,65 +132,34 @@ jobs:
         run: bash patches/curl_stfp_patcher
         shell: bash
         if: success()
-      - name: after_success
+      - name: after_success_buster
+        run: |
+          cp docs/cross-gcc-buster.md $HOME/README.md
+          bash utils/SF_docs_deployer
+        shell: bash
+        if: success() && github.event_name == 'push' && ${{ matrix.rpios_types }} == "buster"
+      - name: after_success_stretch
         run: |
           cp docs/cross-gcc-stretch.md $HOME/README.md
           bash utils/SF_docs_deployer
         shell: bash
-        if: success() && github.event_name == 'push'
+        if: success() && github.event_name == 'push' && ${{ matrix.rpios_types }} == "stretch"
       - name: deploy
         run: bash utils/SF_deployer
         shell: bash
         if: success() && github.event_name == 'release' && github.event.action == 'published'
-  builder-stretch_1_1:
-    name: Cross GCC-6.3.0 32-bit Stretch Pi[2-3]
-    needs: builder-stretch_0
+
+  builder-native:
+    name: Native GCC 32-bit Builder Pi[2-3]
+    needs: [builder-base, builder-cross]
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        gcc_versions: [9.3.0, 10.1.0]
+        rpios_types: [stretch, buster]
     env:
-      GCC_VERSION: 6.3.0  
-      RPIOS_TYPE: stretch 
-      RPI_TYPE: 2-3 
-      COMPILER_TYPE: CROSS
-    steps:
-      - uses: actions/checkout@v2
-      - name: before_install
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -qq dos2unix -y
-          dos2unix build-scripts/CI/CICTB_32b 
-          chmod +x build-scripts/CI/CICTB_32b 
-          dos2unix patches/curl_stfp_patcher
-          chmod +x patches/curl_stfp_patcher
-          dos2unix utils/SF_deployer
-          chmod +x utils/SF_deployer
-        if: success()
-      - name: install
-        run: |
-          sudo apt-get -y install -qq gcc g++ gperf flex texinfo pigz gawk gfortran texinfo bison libncurses-dev ccache autoconf automake build-essential libssh2-1-dev openssl libcurl3 unzip wget
-          sudo /usr/sbin/update-ccache-symlinks
-          echo 'export PATH="/usr/lib/ccache:$PATH"' | tee -a ~/.bashrc
-          source ~/.bashrc && echo $PATH
-        if: success()
-      - name: script
-        run: bash build-scripts/CI/CICTB_32b -g $GCC_VERSION -r $RPI_TYPE -o $RPIOS_TYPE
-        shell: bash
-        if: success()
-      - name: before_script
-        run: bash patches/curl_stfp_patcher
-        shell: bash
-        if: success()
-      - name: deploy
-        run: bash utils/SF_deployer
-        shell: bash
-        if: success() && github.event_name == 'release' && github.event.action == 'published'
-  builder-stretch_2:
-    name: Native GCC-9.3.0 32-bit Stretch Pi[2-3]
-    needs: [builder-stretch_0, builder-stretch_1]
-    runs-on: ubuntu-latest
-    env:
-      GCC_VERSION: 9.3.0  
-      RPIOS_TYPE: stretch 
-      RPI_TYPE: 2-3 
+      GCC_VERSION: ${{ matrix.gcc_versions }}  
+      RPIOS_TYPE: ${{ matrix.rpios_types }}  
       COMPILER_TYPE: NATIVE
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/builder_3_plus.yml
+++ b/.github/workflows/builder_3_plus.yml
@@ -182,13 +182,13 @@ jobs:
           cp docs/native-gcc-buster.md $HOME/README.md
           bash utils/SF_docs_deployer
         shell: bash
-        if: success() && github.event_name == 'push' && ${{ matrix.rpios_types }} == "buster"
+        if: success() && github.event_name == 'release' && ${{ matrix.rpios_types }} == "buster"
       - name: after_success_stretch
         run: |
           cp docs/native-gcc-stretch.md $HOME/README.md
           bash utils/SF_docs_deployer
         shell: bash
-        if: success() && github.event_name == 'push' && ${{ matrix.rpios_types }} == "stretch"
+        if: success() && github.event_name == 'release' && ${{ matrix.rpios_types }} == "stretch"
       - name: deploy
         run: bash utils/SF_deployer
         shell: bash

--- a/.github/workflows/builder_3_plus.yml
+++ b/.github/workflows/builder_3_plus.yml
@@ -39,6 +39,7 @@ on:
       - master
 
 env:
+  RPI_TYPE: 3+
   CURL_VERSION: 7.68.0
   CCACHE_COMPRESS: 1
   CCACHE_DIR: $HOME/.ccache
@@ -46,13 +47,14 @@ env:
   PASSWORD_SFTP: ${{ secrets.PASSWORD_SFTP }}
 
 jobs:
-  builder-buster_0:
-    name: BASE GCC-8.3.0 32-bit Buster Pi[3+]
+  builder-base:
+    name: Base GCC 32-bit Builder Pi[3+]
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rpios_types: [stretch, buster]
     env:
-      GCC_VERSION: 8.3.0  
-      RPIOS_TYPE: buster 
-      RPI_TYPE: 3+
+      RPIOS_TYPE: ${{ matrix.rpios_types }}
       COMPILER_TYPE: CROSS
       BASE: true
     steps:
@@ -76,198 +78,29 @@ jobs:
           source ~/.bashrc && echo $PATH
         if: success()
       - name: script
-        run: bash build-scripts/CI/CIBB_32b -g $GCC_VERSION -r $RPI_TYPE -o $RPIOS_TYPE
+        run: bash build-scripts/CI/CIBB_32b -r $RPI_TYPE -o $RPIOS_TYPE
         shell: bash
         if: success() && github.event_name == 'pull_request'
       - name: before_script
         run: bash patches/curl_stfp_patcher
         shell: bash
         if: success()
-      - name: deploy
-        run: bash utils/SF_deployer
-        shell: bash
-        if: success() && github.event_name == 'release' && github.event.action == 'published'
-  builder-buster_1:
-    name: Cross GCC-9.3.0 32-bit Buster Pi[3+]
-    needs: builder-buster_0
-    runs-on: ubuntu-latest
-    env:
-      GCC_VERSION: 9.3.0  
-      RPIOS_TYPE: buster 
-      RPI_TYPE: 3+
-      COMPILER_TYPE: CROSS
-    steps:
-      - uses: actions/checkout@v2
-      - name: before_install
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -qq dos2unix -y
-          dos2unix build-scripts/CI/CICTB_32b 
-          chmod +x build-scripts/CI/CICTB_32b 
-          dos2unix patches/curl_stfp_patcher
-          chmod +x patches/curl_stfp_patcher
-          dos2unix utils/SF_deployer
-          chmod +x utils/SF_deployer
-        if: success()
-      - name: install
-        run: |
-          sudo apt-get -y install -qq gcc g++ gperf flex texinfo pigz gawk gfortran texinfo bison libncurses-dev ccache autoconf automake build-essential libssh2-1-dev openssl libcurl3 unzip wget
-          sudo /usr/sbin/update-ccache-symlinks
-          echo 'export PATH="/usr/lib/ccache:$PATH"' | tee -a ~/.bashrc
-          source ~/.bashrc && echo $PATH
-        if: success()
-      - name: script
-        run: bash build-scripts/CI/CICTB_32b -g $GCC_VERSION -r $RPI_TYPE -o $RPIOS_TYPE
-        shell: bash
-        if: success()
-      - name: before_script
-        run: bash patches/curl_stfp_patcher
-        shell: bash
-        if: success()
-      - name: deploy
-        run: bash utils/SF_deployer
-        shell: bash
-        if: success() && github.event_name == 'release' && github.event.action == 'published'
-  builder-buster_1_1:
-    name: Cross GCC-8.3.0 32-bit Buster Pi[3+]
-    needs: builder-buster_0
-    runs-on: ubuntu-latest
-    env:
-      GCC_VERSION: 8.3.0  
-      RPIOS_TYPE: buster 
-      RPI_TYPE: 3+
-      COMPILER_TYPE: CROSS
-    steps:
-      - uses: actions/checkout@v2
-      - name: before_install
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -qq dos2unix -y
-          dos2unix build-scripts/CI/CICTB_32b 
-          chmod +x build-scripts/CI/CICTB_32b 
-          dos2unix patches/curl_stfp_patcher
-          chmod +x patches/curl_stfp_patcher
-          dos2unix utils/SF_deployer
-          chmod +x utils/SF_deployer
-        if: success()
-      - name: install
-        run: |
-          sudo apt-get -y install -qq gcc g++ gperf flex texinfo pigz gawk gfortran texinfo bison libncurses-dev ccache autoconf automake build-essential libssh2-1-dev openssl libcurl3 unzip wget
-          sudo /usr/sbin/update-ccache-symlinks
-          echo 'export PATH="/usr/lib/ccache:$PATH"' | tee -a ~/.bashrc
-          source ~/.bashrc && echo $PATH
-        if: success()
-      - name: script
-        run: bash build-scripts/CI/CICTB_32b -g $GCC_VERSION -r $RPI_TYPE -o $RPIOS_TYPE
-        shell: bash
-        if: success()
-      - name: before_script
-        run: bash patches/curl_stfp_patcher
-        shell: bash
-        if: success()
-      - name: deploy
-        run: bash utils/SF_deployer
-        shell: bash
-        if: success() && github.event_name == 'release' && github.event.action == 'published'
-  builder-buster_2:
-    name: Native GCC-9.3.0 32-bit Buster Pi[3+]
-    needs: [builder-buster_0, builder-buster_1]
-    runs-on: ubuntu-latest
-    env:
-      GCC_VERSION: 9.3.0  
-      RPIOS_TYPE: buster 
-      RPI_TYPE: 3+ 
-      COMPILER_TYPE: NATIVE
-    steps:
-      - uses: actions/checkout@v2
-      - name: before_install
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -qq dos2unix -y
-          dos2unix build-scripts/CI/CINTB_32b 
-          chmod +x build-scripts/CI/CINTB_32b 
-          dos2unix patches/curl_stfp_patcher
-          chmod +x patches/curl_stfp_patcher
-          dos2unix utils/SF_deployer
-          chmod +x utils/SF_deployer
-          dos2unix utils/SF_docs_deployer
-          chmod +x utils/SF_docs_deployer
-        if: success()
-      - name: install
-        run: |
-          sudo apt-get -y install -qq gcc g++ gperf flex texinfo pigz gawk gfortran texinfo bison libncurses-dev ccache autoconf automake build-essential libssh2-1-dev openssl libcurl3 unzip wget
-          sudo /usr/sbin/update-ccache-symlinks
-          echo 'export PATH="/usr/lib/ccache:$PATH"' | tee -a ~/.bashrc
-          source ~/.bashrc && echo $PATH
-        if: success()
-      - name: script
-        run: bash build-scripts/CI/CINTB_32b -g $GCC_VERSION -r $RPI_TYPE -o $RPIOS_TYPE
-        shell: bash
-        if: success()
-      - name: before_script
-        run: bash patches/curl_stfp_patcher
-        shell: bash
-        if: success()
-      - name: after_success
-        run: |
-          cp docs/native-gcc-buster.md $HOME/README.md
-          bash utils/SF_docs_deployer
-        shell: bash
-        if: success() && github.event_name == 'push'
       - name: deploy
         run: bash utils/SF_deployer
         shell: bash
         if: success() && github.event_name == 'release' && github.event.action == 'published'
 
-  builder-stretch_0:
-    name: BASE GCC-6.3.0 32-bit Stretch Pi[3+]
+  builder-cross:
+    name: Cross GCC 32-bit Builder Pi[3+]
+    needs: builder-base
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        gcc_versions: [6.3.0, 8.3.0, 9.2.0, 9.3.0, 10.1.0]
+        rpios_types: [stretch, buster]
     env:
-      GCC_VERSION: 6.3.0  
-      RPIOS_TYPE: stretch 
-      RPI_TYPE: 3+
-      COMPILER_TYPE: CROSS
-      BASE: true
-    steps:
-      - uses: actions/checkout@v2
-      - name: before_install
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -qq dos2unix -y
-          dos2unix build-scripts/CI/CIBB_32b 
-          chmod +x build-scripts/CI/CIBB_32b 
-          dos2unix patches/curl_stfp_patcher
-          chmod +x patches/curl_stfp_patcher
-          dos2unix utils/SF_deployer
-          chmod +x utils/SF_deployer
-        if: success()
-      - name: install
-        run: |
-          sudo apt-get -y install -qq gcc g++ gperf flex texinfo pigz gawk gfortran texinfo bison libncurses-dev ccache autoconf automake build-essential libssh2-1-dev openssl libcurl3 unzip wget
-          sudo /usr/sbin/update-ccache-symlinks
-          echo 'export PATH="/usr/lib/ccache:$PATH"' | tee -a ~/.bashrc
-          source ~/.bashrc && echo $PATH
-        if: success()
-      - name: script
-        run: bash build-scripts/CI/CIBB_32b -g $GCC_VERSION -r $RPI_TYPE -o $RPIOS_TYPE
-        shell: bash
-        if: success() && github.event_name == 'pull_request'
-      - name: before_script
-        run: bash patches/curl_stfp_patcher
-        shell: bash
-        if: success()
-      - name: deploy
-        run: bash utils/SF_deployer
-        shell: bash
-        if: success() && github.event_name == 'release' && github.event.action == 'published'
-  builder-stretch_1:
-    name: Cross GCC-9.3.0 32-bit Stretch Pi[3+]
-    needs: builder-stretch_0
-    runs-on: ubuntu-latest
-    env:
-      GCC_VERSION: 9.3.0  
-      RPIOS_TYPE: stretch 
-      RPI_TYPE: 3+
+      GCC_VERSION: ${{ matrix.gcc_versions }}  
+      RPIOS_TYPE: ${{ matrix.rpios_types }} 
       COMPILER_TYPE: CROSS
     steps:
       - uses: actions/checkout@v2
@@ -301,55 +134,18 @@ jobs:
         run: bash utils/SF_deployer
         shell: bash
         if: success() && github.event_name == 'release' && github.event.action == 'published'
-  builder-stretch_1_1:
-    name: Cross GCC-6.3.0 32-bit Stretch Pi[3+]
-    needs: builder-stretch_0
+
+  builder-native:
+    name: Native GCC 32-bit Builder Pi[3+]
+    needs: [builder-base, builder-cross]
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        gcc_versions: [9.3.0, 10.1.0]
+        rpios_types: [stretch, buster]
     env:
-      GCC_VERSION: 6.3.0  
-      RPIOS_TYPE: stretch 
-      RPI_TYPE: 3+
-      COMPILER_TYPE: CROSS
-    steps:
-      - uses: actions/checkout@v2
-      - name: before_install
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -qq dos2unix -y
-          dos2unix build-scripts/CI/CICTB_32b 
-          chmod +x build-scripts/CI/CICTB_32b 
-          dos2unix patches/curl_stfp_patcher
-          chmod +x patches/curl_stfp_patcher
-          dos2unix utils/SF_deployer
-          chmod +x utils/SF_deployer
-        if: success()
-      - name: install
-        run: |
-          sudo apt-get -y install -qq gcc g++ gperf flex texinfo pigz gawk gfortran texinfo bison libncurses-dev ccache autoconf automake build-essential libssh2-1-dev openssl libcurl3 unzip wget
-          sudo /usr/sbin/update-ccache-symlinks
-          echo 'export PATH="/usr/lib/ccache:$PATH"' | tee -a ~/.bashrc
-          source ~/.bashrc && echo $PATH
-        if: success()
-      - name: script
-        run: bash build-scripts/CI/CICTB_32b -g $GCC_VERSION -r $RPI_TYPE -o $RPIOS_TYPE
-        shell: bash
-        if: success()
-      - name: before_script
-        run: bash patches/curl_stfp_patcher
-        shell: bash
-        if: success()
-      - name: deploy
-        run: bash utils/SF_deployer
-        shell: bash
-        if: success() && github.event_name == 'release' && github.event.action == 'published'
-  builder-stretch_2:
-    name: Native GCC-9.3.0 32-bit Stretch Pi[3+]
-    needs: [builder-stretch_0, builder-stretch_1]
-    runs-on: ubuntu-latest
-    env:
-      GCC_VERSION: 9.3.0  
-      RPIOS_TYPE: stretch 
-      RPI_TYPE: 3+ 
+      GCC_VERSION: ${{ matrix.gcc_versions }}  
+      RPIOS_TYPE: ${{ matrix.rpios_types }}  
       COMPILER_TYPE: NATIVE
     steps:
       - uses: actions/checkout@v2
@@ -381,13 +177,20 @@ jobs:
         run: bash patches/curl_stfp_patcher
         shell: bash
         if: success()
-      - name: after_success
+      - name: after_success_buster
+        run: |
+          cp docs/native-gcc-buster.md $HOME/README.md
+          bash utils/SF_docs_deployer
+        shell: bash
+        if: success() && github.event_name == 'push' && ${{ matrix.rpios_types }} == "buster"
+      - name: after_success_stretch
         run: |
           cp docs/native-gcc-stretch.md $HOME/README.md
           bash utils/SF_docs_deployer
         shell: bash
-        if: success() && github.event_name == 'push'
+        if: success() && github.event_name == 'push' && ${{ matrix.rpios_types }} == "stretch"
       - name: deploy
         run: bash utils/SF_deployer
         shell: bash
         if: success() && github.event_name == 'release' && github.event.action == 'published'
+        

--- a/.github/workflows/builder_64.yml
+++ b/.github/workflows/builder_64.yml
@@ -39,6 +39,7 @@ on:
       - master
 
 env:
+  RPI_TYPE: 64
   CURL_VERSION: 7.68.0
   CCACHE_COMPRESS: 1
   CCACHE_DIR: $HOME/.ccache
@@ -46,12 +47,14 @@ env:
   PASSWORD_SFTP: ${{ secrets.PASSWORD_SFTP }}
 
 jobs:
-  builder-64_0:
-    name: BASE GCC-6.3.0 Pi[64]
+  builder-base:
+    name: Base GCC 64-bit Builder Pi[64]
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        gcc_versions: [6.3.0, 8.3.0]
     env:
-      GCC_VERSION: 6.3.0
-      RPI_TYPE: 64 
+      GCC_VERSION: ${{ matrix.gcc_versions }}
       COMPILER_TYPE: CROSS
       BASE: true
     steps:
@@ -95,13 +98,16 @@ jobs:
         run: bash utils/SF_deployer
         shell: bash
         if: success() && github.event_name == 'release' && github.event.action == 'published'
-  builder-64_1:
-    name: Cross GCC-9.3.0 Pi[64]
-    needs: builder-64_0
+
+  builder-cross:
+    name: Cross GCC 64-bit Builder Pi[64]
+    needs: builder-base
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        gcc_versions: [6.3.0, 8.3.0, 9.3.0, 10.1.0]
     env:
-      GCC_VERSION: 9.3.0  
-      RPI_TYPE: 64 
+      GCC_VERSION: ${{ matrix.gcc_versions }}  
       COMPILER_TYPE: CROSS
     steps:
       - uses: actions/checkout@v2
@@ -143,93 +149,16 @@ jobs:
         run: bash utils/SF_deployer
         shell: bash
         if: success() && github.event_name == 'release' && github.event.action == 'published'
-  builder-64_1_0:
-    name: Cross GCC-6.3.0 Pi[64]
-    needs: builder-64_0
+
+  builder-native:
+    name: Native GCC 64-bit Builder Pi[64]
+    needs: [builder-base, builder-cross]
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        gcc_versions: [8.3.0, 9.3.0, 10.1.0]
     env:
-      GCC_VERSION: 6.3.0  
-      RPI_TYPE: 64 
-      COMPILER_TYPE: CROSS
-    steps:
-      - uses: actions/checkout@v2
-      - name: before_install
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -qq dos2unix -y
-          dos2unix build-scripts/CI/CICTB_64b 
-          chmod +x build-scripts/CI/CICTB_64b 
-          dos2unix patches/curl_stfp_patcher
-          chmod +x patches/curl_stfp_patcher
-          dos2unix utils/SF_deployer
-          chmod +x utils/SF_deployer
-        if: success()
-      - name: install
-        run: |
-          sudo apt-get -y install -qq gcc g++ gperf flex texinfo pigz gawk gfortran texinfo bison libncurses-dev ccache autoconf automake build-essential libssh2-1-dev openssl libcurl3 unzip wget
-          sudo /usr/sbin/update-ccache-symlinks
-          echo 'export PATH="/usr/lib/ccache:$PATH"' | tee -a ~/.bashrc
-          source ~/.bashrc && echo $PATH
-        if: success()
-      - name: script
-        run: bash build-scripts/CI/CICTB_64b -g $GCC_VERSION
-        shell: bash
-        if: success()
-      - name: before_script
-        run: bash patches/curl_stfp_patcher
-        shell: bash
-        if: success()
-      - name: deploy
-        run: bash utils/SF_deployer
-        shell: bash
-        if: success() && github.event_name == 'release' && github.event.action == 'published'
-  builder-64_1_1:
-    name: Cross GCC-8.3.0 Pi[64]
-    needs: builder-64_0
-    runs-on: ubuntu-latest
-    env:
-      GCC_VERSION: 8.3.0  
-      RPI_TYPE: 64 
-      COMPILER_TYPE: CROSS
-    steps:
-      - uses: actions/checkout@v2
-      - name: before_install
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -qq dos2unix -y
-          dos2unix build-scripts/CI/CICTB_64b 
-          chmod +x build-scripts/CI/CICTB_64b 
-          dos2unix patches/curl_stfp_patcher
-          chmod +x patches/curl_stfp_patcher
-          dos2unix utils/SF_deployer
-          chmod +x utils/SF_deployer
-        if: success()
-      - name: install
-        run: |
-          sudo apt-get -y install -qq gcc g++ gperf flex texinfo pigz gawk gfortran texinfo bison libncurses-dev ccache autoconf automake build-essential libssh2-1-dev openssl libcurl3 unzip wget
-          sudo /usr/sbin/update-ccache-symlinks
-          echo 'export PATH="/usr/lib/ccache:$PATH"' | tee -a ~/.bashrc
-          source ~/.bashrc && echo $PATH
-        if: success()
-      - name: script
-        run: bash build-scripts/CI/CICTB_64b -g $GCC_VERSION
-        shell: bash
-        if: success()
-      - name: before_script
-        run: bash patches/curl_stfp_patcher
-        shell: bash
-        if: success()
-      - name: deploy
-        run: bash utils/SF_deployer
-        shell: bash
-        if: success() && github.event_name == 'release' && github.event.action == 'published'
-  builder-64_2:
-    name: Native GCC-9.3.0 Pi[64]
-    needs: [builder-64_0, builder-64_1]
-    runs-on: ubuntu-latest
-    env:
-      GCC_VERSION: 9.3.0  
-      RPI_TYPE: 64
+      GCC_VERSION: ${{ matrix.gcc_versions }}  
       COMPILER_TYPE: NATIVE
     steps:
       - uses: actions/checkout@v2
@@ -267,46 +196,6 @@ jobs:
           bash utils/SF_docs_deployer
         shell: bash
         if: success() && github.event_name == 'push'
-      - name: deploy
-        run: bash utils/SF_deployer
-        shell: bash
-        if: success() && github.event_name == 'release' && github.event.action == 'published'
-  builder-64_2_1:
-    name: Native GCC-8.3.0 Pi[64]
-    needs: [builder-64_0, builder-64_1_1]
-    runs-on: ubuntu-latest
-    env:
-      GCC_VERSION: 8.3.0  
-      RPI_TYPE: 64 
-      COMPILER_TYPE: NATIVE
-    steps:
-      - uses: actions/checkout@v2
-      - name: before_install
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -qq dos2unix -y
-          dos2unix build-scripts/CI/CINTB_64b 
-          chmod +x build-scripts/CI/CINTB_64b 
-          dos2unix patches/curl_stfp_patcher
-          chmod +x patches/curl_stfp_patcher
-          dos2unix utils/SF_deployer
-          chmod +x utils/SF_deployer
-        if: success()
-      - name: install
-        run: |
-          sudo apt-get -y install -qq gcc g++ gperf flex texinfo pigz gawk gfortran texinfo bison libncurses-dev ccache autoconf automake build-essential libssh2-1-dev openssl libcurl3 unzip wget
-          sudo /usr/sbin/update-ccache-symlinks
-          echo 'export PATH="/usr/lib/ccache:$PATH"' | tee -a ~/.bashrc
-          source ~/.bashrc && echo $PATH
-        if: success()
-      - name: script
-        run: bash build-scripts/CI/CINTB_64b -g $GCC_VERSION
-        shell: bash
-        if: success()
-      - name: before_script
-        run: bash patches/curl_stfp_patcher
-        shell: bash
-        if: success()
       - name: deploy
         run: bash utils/SF_deployer
         shell: bash

--- a/.github/workflows/builder_64.yml
+++ b/.github/workflows/builder_64.yml
@@ -93,7 +93,7 @@ jobs:
           cp docs/gcc64.md $HOME/root/README.md
           bash utils/SF_docs_deployer
         shell: bash
-        if: success() && github.event_name == 'push'
+        if: success() && github.event_name == 'release'
       - name: deploy
         run: bash utils/SF_deployer
         shell: bash
@@ -144,7 +144,7 @@ jobs:
           cp docs/cross-gcc64.md $HOME/README.md
           bash utils/SF_docs_deployer
         shell: bash
-        if: success() && github.event_name == 'push'
+        if: success() && github.event_name == 'release'
       - name: deploy
         run: bash utils/SF_deployer
         shell: bash
@@ -195,7 +195,7 @@ jobs:
           cp docs/native-gcc64.md $HOME/README.md
           bash utils/SF_docs_deployer
         shell: bash
-        if: success() && github.event_name == 'push'
+        if: success() && github.event_name == 'release'
       - name: deploy
         run: bash utils/SF_deployer
         shell: bash

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 ## Table of Contents
 
 * [**TL'DR**](#tldr)
-* [**New-Release SneekPeak: v3.0**](#new-release-sneekpeak-v30)
+* [**New v3.0+ Release SneekPeak**](#new-release-sneekpeak-v30)
 * **Precompiled Toolchains: Easy-to-Use**
   * [**A. Automated Toolchain Builder Workflow**](#a-automated-toolchain-builder-workflow)
   * [**B. Toolchain Binaries description table**](#b-toolchain-binaries-description-table)
@@ -69,6 +69,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 &nbsp;
 
+&nbsp;
+
 
 ### TL'DR
 
@@ -81,9 +83,11 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 > _This project benefits everyone, from a professional Developer to a small Hobbyist to a research Student, who's looking for latest easy-to-use precompiled GCC toolchains for their Raspberry Pi project(s)._ 
 
 
+&nbsp;
+
 &nbsp; 
 
-### New-Release SneekPeak: v3.0
+### New v3.0+ Release SneekPeak
 
 - *Automated CI maintained GCC standalone ARM/ARM64 toolchains.*
 - *Latest [**GCC 10.1.0**](https://gcc.gnu.org/gcc-10/) toolchains available.*<img src="https://raw.githubusercontent.com/abhiTronix/Imbakup/master/Images/new.gif"/>
@@ -185,7 +189,7 @@ These precompiled toolchains setup requires just three easy steps - **Downloadin
 
 # <img alt="Banner" src="https://raw.githubusercontent.com/abhiTronix/Imbakup/master/Images/gcc/banners-f.png">
 
-Open source is awesome :heart: 
+_Open-Source is awesome :heart:_
 
 - This project now provides user-friendly open-sourced bash build-scripts that auto-generates Compressed Cross & Native GCC ARM/ARM64 Toolchain binaries targeting Raspberry Pi 32-bit & 64-bit OSes.
 
@@ -222,9 +226,8 @@ Open source is awesome :heart:
 
 ### Optimization Flags Involved:
 
-**These toolchains are built with these following system-specific LTO _(Link Time Optimization)_ flags, therefore you can easily take advantage of your Raspberry Pi's CPU specific features with these Toolchains while compiling your programs:**
+These toolchains are built with these following system-specific LTO _(Link Time Optimization)_ flags, therefore you can easily take advantage of your Raspberry Pi's CPU specific features with these Toolchains while compiling your programs:
 
-**Important:** The latest Raspberry Pi 4 uses a Broadcom BCM2711 SoC with a 1.5 GHz 64-bit quad-core ARM Cortex-A72 processor, that also have armv8-a architecture similar to Raspberry Pi 3B+, therefore it is also officially supported!
 
 | Raspberry Pi Board | Link Time Optimization Flags |
 |---|---|
@@ -234,8 +237,11 @@ Open source is awesome :heart:
 | Raspberry Pi - *3 & 4 Model A+/B+ & Compute 3/3-lite/3+ (64-Bit)* | `-march=armv8-a+fp+simd` |
 
 
+**Important: :bulb:** _The latest Raspberry Pi 4 uses a Broadcom BCM2711 SoC with a 1.5 GHz 64-bit quad-core ARM Cortex-A72 processor, that also have armv8-a architecture similar to Raspberry Pi 3B+, therefore it is also officially supported!_
+
 &nbsp; 
 
+&nbsp;
 
 # Citing
 
@@ -253,12 +259,16 @@ Open source is awesome :heart:
 
 &nbsp; 
 
+&nbsp;
+
 
 # Copyright License
 
 **Copyright © 2020 abhiTronix**
 
 This Project source-code and its precompiled binaries are licensed under the [**GPLv3**][license] license.
+
+&nbsp;
 
 &nbsp; 
  

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 [![Open Source Love png1](https://badges.frapsoft.com/os/v1/open-source.png?v=103)](https://github.com/abhiTronix/raspberry-pi-cross-compilers)
 [![License][license-badge]][license]
-[![made-with-bash](https://img.shields.io/badge/Made%20with-Bash-1f425f.svg?style=flat&logo=github)](https://www.gnu.org/software/bash)
+![GitHub release (latest by date)](https://img.shields.io/github/v/release/abhiTronix/raspberry-pi-cross-compilers?logo=github)
 [![Downloads][downloads-badge]][downloads]
 
 [![ko-fi][kofi-badge]][kofi]
@@ -78,20 +78,20 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 **Who will benefit from the project?**
 
-> _This project benefits everyone, from a professional Developer to a small Hobbyist to a research Student, who's looking for latest easy-to-use precompiled GCC toolchains and build-scripts for there Raspberry Pi project(s)._ 
+> _This project benefits everyone, from a professional Developer to a small Hobbyist to a research Student, who's looking for latest easy-to-use precompiled GCC toolchains for their Raspberry Pi project(s)._ 
 
 
 &nbsp; 
 
 ### New-Release SneekPeak: v3.0
 
-- *Automated CI maintained GCC standalone ARM/ARM64 toolchains.*<img src="https://raw.githubusercontent.com/abhiTronix/Imbakup/master/Images/new.gif"/>
-- *Latest [**GCC 9.3.0**](https://gcc.gnu.org/gcc-9/) toolchains available.*<img src="https://raw.githubusercontent.com/abhiTronix/Imbakup/master/Images/new.gif"/>
-- *Hardcoded paths free both Cross & Native **Raspbian Buster (Debian 10)** toolchains available.*<img src="https://raw.githubusercontent.com/abhiTronix/Imbakup/master/Images/new.gif"/>
+- *Automated CI maintained GCC standalone ARM/ARM64 toolchains.*
+- *Latest [**GCC 10.1.0**](https://gcc.gnu.org/gcc-10/) toolchains available.*<img src="https://raw.githubusercontent.com/abhiTronix/Imbakup/master/Images/new.gif"/>
+- *Hardcoded paths free both Cross & Native **Raspbian Buster (Debian 10)** toolchains available.*
 - *Separate binaries for each Raspberry Pi variant (including latest Compute modules and Raspberry Pi 4).*
 - *Tar Compressed binaries with maximum possible compression.*
 - *Exclusive **ARM64|AARCH64** Binaries for Raspberry Pi 64-Bit kernel OS flavors.*
-- *Open-sourced Toolchains build-scripts are also available.*<img src="https://raw.githubusercontent.com/abhiTronix/Imbakup/master/Images/new.gif"/>
+- *Open-sourced Toolchains build-scripts are also available.*
 - *Latest [**GDB Debugger v9.1**](https://www.gnu.org/software/gdb/download/ANNOUNCEMENT) included in all binaries.*<img src="https://raw.githubusercontent.com/abhiTronix/Imbakup/master/Images/new.gif"/>
 
 
@@ -124,14 +124,13 @@ This project now utilizes powerful [**Github Actions**][git-action] CI(Continuou
 
 | Toolchains | Host OS | Target OS | Current Status | Precompiled GCC versions available |
 | :---------- | :--------: | :-------: | :--------: | :------------------------: |
-| **Raspberry Pi GCC Cross-Compiler Toolchains(Stretch)** | any x64/x86 Linux machine | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 6.3.0,  9.2.0, 9.3.0 |
-| **Raspberry Pi GCC Cross-Compiler Toolchains(Buster)** | any x64/x86 Linux machine | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 8.3.0, 9.2.0, 9.3.0 |
-| **Raspberry Pi GCC Native-Compiler Toolchains(Stretch)** | Raspbian Stretch OS (Debian Version 9) only | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 9.2.0, 9.3.0 |
-| **Raspberry Pi GCC Native-Compiler Toolchains(Buster)** | Raspbian Buster OS (Debian Version 10) only | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 9.2.0, 9.3.0 |
-| **Raspberry Pi GCC 64-Bit Cross-Compiler Toolchains** | any x64/x86 Linux machine | any x64 Raspberry Pi OS(like Pi64) | Stable/Production | 6.3.0, 8.3.0, 9.2.0, 9.3.0 |
-| **Raspberry Pi GCC 64-Bit Native-Compiler Toolchains** | any x64 Raspberry Pi OS(like Pi64) | any x64 Raspbian OS(like Pi64) | Stable/Production | 8.3.0, 9.2.0, 9.3.0 |
+| **Raspberry Pi GCC Cross-Compiler Toolchains(Stretch)** | any x64/x86 Linux machine | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 6.3.0,  9.2.0, 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC Cross-Compiler Toolchains(Buster)** | any x64/x86 Linux machine | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 8.3.0, 9.2.0, 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC Native-Compiler Toolchains(Stretch)** | Raspbian Stretch OS (Debian Version 9) only | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC Native-Compiler Toolchains(Buster)** | Raspbian Buster OS (Debian Version 10) only | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC 64-Bit Cross-Compiler Toolchains** | any x64/x86 Linux machine | any x64 Raspberry Pi OS(like Pi64) | Stable/Production | 6.3.0, 8.3.0, 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC 64-Bit Native-Compiler Toolchains** | any x64 Raspberry Pi OS(like Pi64) | any x64 Raspbian OS(like Pi64) | Stable/Production | 8.3.0, 9.3.0, 10.1.0 |
 | **Exclusive/Experimental Toolchains** |  None | None | Beta/Experimental | None | 
- 
 
 
 &nbsp;
@@ -150,12 +149,12 @@ You can easily identify each pre-compiled toolchain binary by its name as follow
 
 | Toolchains Binaries | Status | GCC versions |
 | ---------- | -------- | :------: |
-| **Raspberry Pi GCC Cross-Compiler Toolchains(Stretch)**  | Stable/Production | [6.3.0][cc-stretch-630], [9.2.0][cc-stretch-920], [9.3.0][cc-stretch-930] |
-| **Raspberry Pi GCC Cross-Compiler Toolchains(Buster)** | Stable/Production | [8.3.0][cc-buster-830], [9.2.0][cc-buster-920], [9.3.0][cc-buster-930] |
-| **Raspberry Pi GCC Native-Compiler Toolchains(Stretch)** | Stable/Production | [9.2.0][nc-stretch-920], [9.3.0][nc-stretch-930] |
-| **Raspberry Pi GCC Native-Compiler Toolchains(Buster)** | Stable/Production | [9.2.0][nc-buster-920], [9.3.0][nc-buster-930] |
-| **Raspberry Pi GCC 64-Bit Cross-Compiler Toolchains** | Stable/Production | [6.3.0][cc-64-630], [8.3.0][cc-64-830], [9.2.0][cc-64-920], [9.3.0][cc-64-930] |
-| **Raspberry Pi GCC 64-Bit Native-Compiler Toolchains** | Stable/Production | [8.3.0][nc-64-830], [9.2.0][nc-64-920], [9.3.0][nc-64-930] |
+| **Raspberry Pi GCC Cross-Compiler Toolchains(Stretch)**  | Stable/Production | [6.3.0][cc-stretch-630], [9.2.0][cc-stretch-920], [9.3.0][cc-stretch-930], [10.1.0][cc-stretch-1010] |
+| **Raspberry Pi GCC Cross-Compiler Toolchains(Buster)** | Stable/Production | [8.3.0][cc-buster-830], [9.2.0][cc-buster-920], [9.3.0][cc-buster-930], [10.1.0][cc-buster-1010] |
+| **Raspberry Pi GCC Native-Compiler Toolchains(Stretch)** | Stable/Production | [9.3.0][nc-stretch-930], [10.1.0][nc-stretch-1010] |
+| **Raspberry Pi GCC Native-Compiler Toolchains(Buster)** | Stable/Production | [9.3.0][nc-buster-930], [10.1.0][nc-buster-1010] |
+| **Raspberry Pi GCC 64-Bit Cross-Compiler Toolchains** | Stable/Production | [6.3.0][cc-64-630], [8.3.0][cc-64-830], [9.3.0][cc-64-930], [10.1.0][cc-64-1010]|
+| **Raspberry Pi GCC 64-Bit Native-Compiler Toolchains** | Stable/Production | [8.3.0][nc-64-830], [9.3.0][nc-64-930], [10.1.0][nc-64-1010] |
 | **Exclusive/Experimental Toolchains** |  Beta/Experimental | None |  
 
 
@@ -242,11 +241,12 @@ Open source is awesome :heart:
 
 **Here is a Bibtex entry you can use to cite this project in a publication:**
 
-```bibtex
+```BibTeX
 @misc{raspberry-pi-cross-compilers,
     Title = {Raspberry Pi Toolchains},
     Author = {Abhishek Thakur},
-    howpublished = {\url{https://github.com/abhiTronix/raspberry-pi-cross-compilers}}   
+    howpublished = {\url{https://github.com/abhiTronix/raspberry-pi-cross-compilers}},
+    year = {2020}  
   }
 ```
 
@@ -291,17 +291,19 @@ Thank you,
 [cc-stretch-630]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Stretch/GCC%206.3.0/
 [cc-stretch-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Stretch/GCC%209.2.0/
 [cc-stretch-930]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Stretch/GCC%209.3.0/
+[cc-stretch-1010]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Stretch/GCC%2010.1.0/
 [cc-buster-830]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Buster/GCC%208.3.0/
 [cc-buster-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Buster/GCC%209.2.0/
 [cc-buster-930]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Buster/GCC%209.3.0/
-[nc-stretch-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Native-Compiler%20Toolchains/Stretch/
-[nc-buster-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Native-Compiler%20Toolchains/Buster/
-[nc-stretch-930]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Native-Compiler%20Toolchains/Stretch/
-[nc-buster-930]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Native-Compiler%20Toolchains/Buster/
+[cc-buster-1010]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Buster/GCC%2010.1.0/
+[nc-stretch-1010]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Native-Compiler%20Toolchains/Stretch/GCC%2010.1.0/
+[nc-buster-1010]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Native-Compiler%20Toolchains/Buster/GCC%2010.1.0/
+[nc-stretch-930]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Native-Compiler%20Toolchains/Stretch/GCC%209.3.0/
+[nc-buster-930]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Native-Compiler%20Toolchains/Buster/GCC%209.3.0/
 [cc-64-630]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Bonus%20Raspberry%20Pi%20GCC%2064-Bit%20Toolchains/Raspberry%20Pi%20GCC%2064-Bit%20Cross-Compiler%20Toolchains/GCC%206.3.0/
 [cc-64-830]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Bonus%20Raspberry%20Pi%20GCC%2064-Bit%20Toolchains/Raspberry%20Pi%20GCC%2064-Bit%20Cross-Compiler%20Toolchains/GCC%208.3.0/
-[cc-64-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Bonus%20Raspberry%20Pi%20GCC%2064-Bit%20Toolchains/Raspberry%20Pi%20GCC%2064-Bit%20Cross-Compiler%20Toolchains/GCC%209.2.0/
+[cc-64-1010]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Bonus%20Raspberry%20Pi%20GCC%2064-Bit%20Toolchains/Raspberry%20Pi%20GCC%2064-Bit%20Cross-Compiler%20Toolchains/GCC%2010.1.0/
 [cc-64-930]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Bonus%20Raspberry%20Pi%20GCC%2064-Bit%20Toolchains/Raspberry%20Pi%20GCC%2064-Bit%20Cross-Compiler%20Toolchains/GCC%209.3.0/
 [nc-64-830]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Bonus%20Raspberry%20Pi%20GCC%2064-Bit%20Toolchains/Raspberry%20Pi%20GCC%2064-Bit%20Native-Compiler%20Toolchains/GCC%208.3.0/
-[nc-64-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Bonus%20Raspberry%20Pi%20GCC%2064-Bit%20Toolchains/Raspberry%20Pi%20GCC%2064-Bit%20Native-Compiler%20Toolchains/GCC%209.2.0/
+[nc-64-1010]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Bonus%20Raspberry%20Pi%20GCC%2064-Bit%20Toolchains/Raspberry%20Pi%20GCC%2064-Bit%20Native-Compiler%20Toolchains/GCC%2010.1.0/
 [nc-64-930]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Bonus%20Raspberry%20Pi%20GCC%2064-Bit%20Toolchains/Raspberry%20Pi%20GCC%2064-Bit%20Native-Compiler%20Toolchains/GCC%209.3.0/

--- a/build-scripts/CI/CIBB_32b
+++ b/build-scripts/CI/CIBB_32b
@@ -42,7 +42,6 @@ helpfunction()
    echo ""
    echo ""
    echo "Usage: $0 -g [GCC version] -r [Target Pi type] -o [Target Pi OS type]"
-   echo -e "\t-g GCC base version?: (6.3.0|8.3.0)"
    echo -e "\t-r What's yours Raspberry Pi type?: (0-1|2-3|3+)"
    echo -e "\t-o What's yours Raspberry Pi OS type?: (stretch|buster)"
    echo ""
@@ -52,23 +51,20 @@ helpfunction()
 
 
 #input arguments handler
-while getopts "g:r:o:" opt
+while getopts "r:o:" opt
 do
    case "$opt" in
-   	  g ) GCC_VERSION="$OPTARG" ;;
       r ) RPI_TYPE="$OPTARG" ;;
       o ) RPIOS_TYPE="$OPTARG" ;;
       ? ) helpfunction ;; #prints help function for invalid parameter
    esac
 done
 #validates parameters and print usage helper function in case parameters are missing
-if [ -z "$GCC_VERSION" ] || [ -z "$RPI_TYPE" ] || [ -z "$RPIOS_TYPE" ]
+if [ -z "$RPI_TYPE" ] || [ -z "$RPIOS_TYPE" ]
 then
    echo "Required parameters are missing!";
    helpfunction
 fi
-
-
 
 #collect parameters from raspbery pi type
 if [ "$RPI_TYPE" = "2-3" ]; then
@@ -95,9 +91,11 @@ fi
 if [ "$RPIOS_TYPE" = "stretch" ]; then
 	GLIBC_VERSION=2.24
 	BINUTILS_VERSION=2.28
+	GCC_VERSION=6.3.0 #enforced
 elif [ "$RPIOS_TYPE" = "buster" ]; then
 	GLIBC_VERSION=2.28
 	BINUTILS_VERSION=2.31
+	GCC_VERSION=8.3.0 #enforced
 else
 	echo "Invalid argument value: $RPIOS_TYPE"
 	exit

--- a/build-scripts/CI/CICTB_32b
+++ b/build-scripts/CI/CICTB_32b
@@ -42,7 +42,7 @@ helpfunction()
    echo ""
    echo ""
    echo "Usage: $0 -g [GCC version] -r [Target Pi type] -o [Target Pi OS type]"
-   echo -e "\t-g GCC version you want to compile?: (7.1.0|7.2.0|7.3.0|7.4.0|7.5.0|8.1.0|8.2.0|8.3.0|9.1.0|9.2.0|9.3.0)"
+   echo -e "\t-g GCC version you want to compile?: (7.1.0|7.2.0|7.3.0|7.4.0|7.5.0|8.1.0|8.2.0|8.3.0|8.4.0|9.1.0|9.2.0|9.3.0|10.1.0)"
    echo -e "\t-r What's yours Target Raspberry Pi type?: (0-1|2-3|3+)"
    echo -e "\t-o What's yours Target Raspberry Pi OS type?: (stretch|buster)"
    echo ""
@@ -90,13 +90,18 @@ else
 fi
 
 #collect dependencies versions from raspberry pi os
-if [ "$RPIOS_TYPE" = "stretch" ] || [ "$GCC_VERSION" \< "8.3.0" ]; then
+if [ "$RPIOS_TYPE" = "stretch" ]; then
 	GCCBASE_VERSION=6.3.0
 elif [ "$RPIOS_TYPE" = "buster" ]; then
-	GCCBASE_VERSION=8.3.0
+	if [ "$GCC_VERSION" \< "8.3.0" ]; then
+        echo "$GCC_VERSION is not supported on buster!"
+		exit 0
+	else
+		GCCBASE_VERSION=8.3.0
+	fi
 else
 	echo "Invalid argument value: $RPIOS_TYPE"
-	exit
+	exit 1
 fi
 
 #collect build directory if not defined

--- a/build-scripts/CI/CINTB_32b
+++ b/build-scripts/CI/CINTB_32b
@@ -42,7 +42,7 @@ helpfunction()
    echo ""
    echo ""
    echo "Usage: $0 -g [GCC version] -r [Target Pi type] -o [Target Pi OS type]"
-   echo -e "\t-g GCC version you want to compile?: (7.1.0|7.2.0|7.3.0|7.4.0|7.5.0|8.1.0|8.2.0|8.3.0|9.1.0|9.2.0|9.3.0)"
+   echo -e "\t-g GCC version you want to compile?: (7.1.0|7.2.0|7.3.0|7.4.0|7.5.0|8.1.0|8.2.0|8.3.0|8.4.0|9.1.0|9.2.0|9.3.0|10.1.0)"
    echo -e "\t-r What's yours Target Raspberry Pi type?: (0-1|2-3|3+)"
    echo -e "\t-o What's yours Target Raspberry Pi OS type?: (stretch|buster)"
    echo ""
@@ -69,6 +69,14 @@ then
    helpfunction
 fi
 
+
+
+if [ "$RPIOS_TYPE" = "buster" ]; then
+	if [ "$GCC_VERSION" \< "8.3.0" ]; then
+        echo "$GCC_VERSION is not supported on buster!"
+		exit 0
+	fi
+fi
 
 
 #collect parameters from raspbery pi type

--- a/build-scripts/CI/README.md
+++ b/build-scripts/CI/README.md
@@ -81,12 +81,13 @@ These CI build-scripts only support specific Programming Languages, those are as
 
 ## Supported GCC Versions:
 
-These CI build-scripts only support newer GCC versions, those are as follows:
+These CI build-scripts supports newer as well as base GCC versions, those are as follows:
 
 - 6.3.0
 - 8.3.0
+- 9.2.0
 - 9.3.0
-
+- 10.1.0
 
 &nbsp;
 

--- a/build-scripts/README.md
+++ b/build-scripts/README.md
@@ -110,7 +110,7 @@ You can run these bash scripts to manually compile any GCC toolchains version th
   
         ```shellsession
         Usage: ./RTBuilder_32b -g [GCC version] -r [Target Pi type] -o [Target Pi OS type]
-            -g GCC version you want to compile?: (7.1.0|7.2.0|7.3.0|7.4.0|7.5.0|8.1.0|8.2.0|8.3.0|9.1.0|9.2.0|9.3.0)
+            -g GCC version you want to compile?: (7.1.0|7.2.0|7.3.0|7.4.0|7.5.0|8.1.0|8.2.0|8.3.0|8.4.0|9.1.0|9.2.0|9.3.0|10.1.0)
             -r What's yours Raspberry Pi type?: (0-1|2-3|3+)
             -o What's yours Raspberry Pi OS type?: (stretch|buster)
         ```
@@ -136,7 +136,7 @@ You can run these bash scripts to manually compile any GCC toolchains version th
       
         ```shellsession
         Usage: ./RTBuilder_64b -g [GCC version] -t [OS Type]
-            -g GCC version you want to compile?: (7.1.0|7.2.0|7.3.0|7.4.0|7.5.0|8.1.0|8.2.0|8.3.0|9.1.0|9.2.0|9.3.0)
+            -g GCC version you want to compile?: (7.1.0|7.2.0|7.3.0|7.4.0|7.5.0|8.1.0|8.2.0|8.3.0|8.4.0|9.1.0|9.2.0|9.3.0|10.1.0)
             -t What's yours Raspberry Pi OS type?: (1|2) [default:1]
 
         ``` 
@@ -190,10 +190,11 @@ These scripts only support newer GCC versions, those are as follows:
 | 8.1.0 | supported | x | supported |
 | 8.2.0 | supported | x | supported |
 | 8.3.0 | supported | supported | supported |
+| 8.4.0 | supported | supported | supported |
 | 9.1.0 | supported | supported | supported |
 | 9.2.0 | supported | supported | supported |
 | 9.3.0 | supported | supported | supported |
-
+| 10.1.0 | supported | supported | supported |
 
 &nbsp;
 
@@ -212,11 +213,12 @@ These scripts only support newer GCC versions, those are as follows:
 
 **Here is a Bibtex entry you can use to cite this project in a publication:**
 
-```tex
+```BibTeX
 @misc{raspberry-pi-cross-compilers,
     Title = {Raspberry Pi Toolchains},
     Author = {Abhishek Thakur},
-    howpublished = {\url{https://github.com/abhiTronix/raspberry-pi-cross-compilers}}   
+    howpublished = {\url{https://github.com/abhiTronix/raspberry-pi-cross-compilers}},
+    year = {2020}  
   }
 ```
 

--- a/docs/base-gcc.md
+++ b/docs/base-gcc.md
@@ -71,12 +71,12 @@ This project now utilizes powerful [**Github Actions**][git-action] CI(Continuou
 
 | Toolchains | Host OS | Target OS | Current Status | Precompiled GCC versions available |
 | :---------- | :--------: | :-------: | :--------: | :------------------------: |
-| **Raspberry Pi GCC Cross-Compiler Toolchains(Stretch)** | any x64/x86 Linux machine | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 6.3.0,  9.2.0, 9.3.0 |
-| **Raspberry Pi GCC Cross-Compiler Toolchains(Buster)** | any x64/x86 Linux machine | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 8.3.0, 9.2.0, 9.3.0 |
-| **Raspberry Pi GCC Native-Compiler Toolchains(Stretch)** | Raspbian Stretch OS (Debian Version 9) only | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 9.2.0, 9.3.0 |
-| **Raspberry Pi GCC Native-Compiler Toolchains(Buster)** | Raspbian Buster OS (Debian Version 10) only | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 9.2.0, 9.3.0 |
-| **Raspberry Pi GCC 64-Bit Cross-Compiler Toolchains** | any x64/x86 Linux machine | any x64 Raspberry Pi OS(like Pi64) | Stable/Production | 6.3.0, 8.3.0, 9.2.0, 9.3.0 |
-| **Raspberry Pi GCC 64-Bit Native-Compiler Toolchains** | any x64 Raspberry Pi OS(like Pi64) | any x64 Raspbian OS(like Pi64) | Stable/Production | 8.3.0, 9.2.0, 9.3.0 |
+| **Raspberry Pi GCC Cross-Compiler Toolchains(Stretch)** | any x64/x86 Linux machine | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 6.3.0,  9.2.0, 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC Cross-Compiler Toolchains(Buster)** | any x64/x86 Linux machine | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 8.3.0, 9.2.0, 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC Native-Compiler Toolchains(Stretch)** | Raspbian Stretch OS (Debian Version 9) only | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC Native-Compiler Toolchains(Buster)** | Raspbian Buster OS (Debian Version 10) only | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC 64-Bit Cross-Compiler Toolchains** | any x64/x86 Linux machine | any x64 Raspberry Pi OS(like Pi64) | Stable/Production | 6.3.0, 8.3.0, 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC 64-Bit Native-Compiler Toolchains** | any x64 Raspberry Pi OS(like Pi64) | any x64 Raspbian OS(like Pi64) | Stable/Production | 8.3.0, 9.3.0, 10.1.0 |
 | **Exclusive/Experimental Toolchains** |  None | None | Beta/Experimental | None | 
 
 
@@ -162,11 +162,12 @@ These precompiled toolchains setup requires just three easy steps - **Downloadin
 
 **Here is a Bibtex entry you can use to cite this project in a publication:**
 
-```bibtex
+```BibTeX
 @misc{raspberry-pi-cross-compilers,
     Title = {Raspberry Pi Toolchains},
     Author = {Abhishek Thakur},
-    howpublished = {\url{https://github.com/abhiTronix/raspberry-pi-cross-compilers}}   
+    howpublished = {\url{https://github.com/abhiTronix/raspberry-pi-cross-compilers}},
+    year = {2020}  
   }
 ```
 

--- a/docs/cross-gcc-buster.md
+++ b/docs/cross-gcc-buster.md
@@ -69,12 +69,12 @@ This project now utilizes powerful [**Github Actions**][git-action] CI(Continuou
 
 | Toolchains | Host OS | Target OS | Current Status | Precompiled GCC versions available |
 | :---------- | :--------: | :-------: | :--------: | :------------------------: |
-| **Raspberry Pi GCC Cross-Compiler Toolchains(Stretch)** | any x64/x86 Linux machine | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 6.3.0,  9.2.0, 9.3.0 |
-| **Raspberry Pi GCC Cross-Compiler Toolchains(Buster)** | any x64/x86 Linux machine | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 8.3.0, 9.2.0, 9.3.0 |
-| **Raspberry Pi GCC Native-Compiler Toolchains(Stretch)** | Raspbian Stretch OS (Debian Version 9) only | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 9.2.0, 9.3.0 |
-| **Raspberry Pi GCC Native-Compiler Toolchains(Buster)** | Raspbian Buster OS (Debian Version 10) only | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 9.2.0, 9.3.0 |
-| **Raspberry Pi GCC 64-Bit Cross-Compiler Toolchains** | any x64/x86 Linux machine | any x64 Raspberry Pi OS(like Pi64) | Stable/Production | 6.3.0, 8.3.0, 9.2.0, 9.3.0 |
-| **Raspberry Pi GCC 64-Bit Native-Compiler Toolchains** | any x64 Raspberry Pi OS(like Pi64) | any x64 Raspbian OS(like Pi64) | Stable/Production | 8.3.0, 9.2.0, 9.3.0 |
+| **Raspberry Pi GCC Cross-Compiler Toolchains(Stretch)** | any x64/x86 Linux machine | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 6.3.0,  9.2.0, 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC Cross-Compiler Toolchains(Buster)** | any x64/x86 Linux machine | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 8.3.0, 9.2.0, 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC Native-Compiler Toolchains(Stretch)** | Raspbian Stretch OS (Debian Version 9) only | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC Native-Compiler Toolchains(Buster)** | Raspbian Buster OS (Debian Version 10) only | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC 64-Bit Cross-Compiler Toolchains** | any x64/x86 Linux machine | any x64 Raspberry Pi OS(like Pi64) | Stable/Production | 6.3.0, 8.3.0, 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC 64-Bit Native-Compiler Toolchains** | any x64 Raspberry Pi OS(like Pi64) | any x64 Raspbian OS(like Pi64) | Stable/Production | 8.3.0, 9.3.0, 10.1.0 |
 | **Exclusive/Experimental Toolchains** |  None | None | Beta/Experimental | None | 
    
 
@@ -160,11 +160,12 @@ These precompiled toolchains setup requires just three easy steps - **Downloadin
 
 **Here is a Bibtex entry you can use to cite this project in a publication:**
 
-```bibtex
+```BibTeX
 @misc{raspberry-pi-cross-compilers,
     Title = {Raspberry Pi Toolchains},
     Author = {Abhishek Thakur},
-    howpublished = {\url{https://github.com/abhiTronix/raspberry-pi-cross-compilers}}   
+    howpublished = {\url{https://github.com/abhiTronix/raspberry-pi-cross-compilers}},
+    year = {2020}  
   }
 ```
 

--- a/docs/cross-gcc-stretch.md
+++ b/docs/cross-gcc-stretch.md
@@ -71,12 +71,12 @@ This project now utilizes powerful [**Github Actions**][git-action] CI(Continuou
 
 | Toolchains | Host OS | Target OS | Current Status | Precompiled GCC versions available |
 | :---------- | :--------: | :-------: | :--------: | :------------------------: |
-| **Raspberry Pi GCC Cross-Compiler Toolchains(Stretch)** | any x64/x86 Linux machine | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 6.3.0,  9.2.0, 9.3.0 |
-| **Raspberry Pi GCC Cross-Compiler Toolchains(Buster)** | any x64/x86 Linux machine | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 8.3.0, 9.2.0, 9.3.0 |
-| **Raspberry Pi GCC Native-Compiler Toolchains(Stretch)** | Raspbian Stretch OS (Debian Version 9) only | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 9.2.0, 9.3.0 |
-| **Raspberry Pi GCC Native-Compiler Toolchains(Buster)** | Raspbian Buster OS (Debian Version 10) only | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 9.2.0, 9.3.0 |
-| **Raspberry Pi GCC 64-Bit Cross-Compiler Toolchains** | any x64/x86 Linux machine | any x64 Raspberry Pi OS(like Pi64) | Stable/Production | 6.3.0, 8.3.0, 9.2.0, 9.3.0 |
-| **Raspberry Pi GCC 64-Bit Native-Compiler Toolchains** | any x64 Raspberry Pi OS(like Pi64) | any x64 Raspbian OS(like Pi64) | Stable/Production | 8.3.0, 9.2.0, 9.3.0 |
+| **Raspberry Pi GCC Cross-Compiler Toolchains(Stretch)** | any x64/x86 Linux machine | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 6.3.0,  9.2.0, 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC Cross-Compiler Toolchains(Buster)** | any x64/x86 Linux machine | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 8.3.0, 9.2.0, 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC Native-Compiler Toolchains(Stretch)** | Raspbian Stretch OS (Debian Version 9) only | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC Native-Compiler Toolchains(Buster)** | Raspbian Buster OS (Debian Version 10) only | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC 64-Bit Cross-Compiler Toolchains** | any x64/x86 Linux machine | any x64 Raspberry Pi OS(like Pi64) | Stable/Production | 6.3.0, 8.3.0, 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC 64-Bit Native-Compiler Toolchains** | any x64 Raspberry Pi OS(like Pi64) | any x64 Raspbian OS(like Pi64) | Stable/Production | 8.3.0, 9.3.0, 10.1.0 |
 | **Exclusive/Experimental Toolchains** |  None | None | Beta/Experimental | None | 
 
 
@@ -162,11 +162,12 @@ These precompiled toolchains setup requires just three easy steps - **Downloadin
 
 **Here is a Bibtex entry you can use to cite this project in a publication:**
 
-```bibtex
+```BibTeX
 @misc{raspberry-pi-cross-compilers,
     Title = {Raspberry Pi Toolchains},
     Author = {Abhishek Thakur},
-    howpublished = {\url{https://github.com/abhiTronix/raspberry-pi-cross-compilers}}   
+    howpublished = {\url{https://github.com/abhiTronix/raspberry-pi-cross-compilers}},
+    year = {2020}  
   }
 ```
 

--- a/docs/cross-gcc.md
+++ b/docs/cross-gcc.md
@@ -70,12 +70,12 @@ This project now utilizes powerful [**Github Actions**][git-action] CI(Continuou
 
 | Toolchains | Host OS | Target OS | Current Status | Precompiled GCC versions available |
 | :---------- | :--------: | :-------: | :--------: | :------------------------: |
-| **Raspberry Pi GCC Cross-Compiler Toolchains(Stretch)** | any x64/x86 Linux machine | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 6.3.0,  9.2.0, 9.3.0 |
-| **Raspberry Pi GCC Cross-Compiler Toolchains(Buster)** | any x64/x86 Linux machine | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 8.3.0, 9.2.0, 9.3.0 |
-| **Raspberry Pi GCC Native-Compiler Toolchains(Stretch)** | Raspbian Stretch OS (Debian Version 9) only | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 9.2.0, 9.3.0 |
-| **Raspberry Pi GCC Native-Compiler Toolchains(Buster)** | Raspbian Buster OS (Debian Version 10) only | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 9.2.0, 9.3.0 |
-| **Raspberry Pi GCC 64-Bit Cross-Compiler Toolchains** | any x64/x86 Linux machine | any x64 Raspberry Pi OS(like Pi64) | Stable/Production | 6.3.0, 8.3.0, 9.2.0, 9.3.0 |
-| **Raspberry Pi GCC 64-Bit Native-Compiler Toolchains** | any x64 Raspberry Pi OS(like Pi64) | any x64 Raspbian OS(like Pi64) | Stable/Production | 8.3.0, 9.2.0, 9.3.0 |
+| **Raspberry Pi GCC Cross-Compiler Toolchains(Stretch)** | any x64/x86 Linux machine | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 6.3.0,  9.2.0, 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC Cross-Compiler Toolchains(Buster)** | any x64/x86 Linux machine | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 8.3.0, 9.2.0, 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC Native-Compiler Toolchains(Stretch)** | Raspbian Stretch OS (Debian Version 9) only | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC Native-Compiler Toolchains(Buster)** | Raspbian Buster OS (Debian Version 10) only | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC 64-Bit Cross-Compiler Toolchains** | any x64/x86 Linux machine | any x64 Raspberry Pi OS(like Pi64) | Stable/Production | 6.3.0, 8.3.0, 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC 64-Bit Native-Compiler Toolchains** | any x64 Raspberry Pi OS(like Pi64) | any x64 Raspbian OS(like Pi64) | Stable/Production | 8.3.0, 9.3.0, 10.1.0 |
 | **Exclusive/Experimental Toolchains** |  None | None | Beta/Experimental | None | 
 
 
@@ -161,11 +161,12 @@ These precompiled toolchains setup requires just three easy steps - **Downloadin
 
 **Here is a Bibtex entry you can use to cite this project in a publication:**
 
-```bibtex
+```BibTeX
 @misc{raspberry-pi-cross-compilers,
     Title = {Raspberry Pi Toolchains},
     Author = {Abhishek Thakur},
-    howpublished = {\url{https://github.com/abhiTronix/raspberry-pi-cross-compilers}}   
+    howpublished = {\url{https://github.com/abhiTronix/raspberry-pi-cross-compilers}},
+    year = {2020}  
   }
 ```
 

--- a/docs/cross-gcc64.md
+++ b/docs/cross-gcc64.md
@@ -69,13 +69,13 @@ This project now utilizes powerful [**Github Actions**][git-action] CI(Continuou
 
 | Toolchains | Host OS | Target OS | Current Status | Precompiled GCC versions available |
 | :---------- | :--------: | :-------: | :--------: | :------------------------: |
-| **Raspberry Pi GCC Cross-Compiler Toolchains(Stretch)** | any x64/x86 Linux machine | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 6.3.0,  9.2.0, 9.3.0 |
-| **Raspberry Pi GCC Cross-Compiler Toolchains(Buster)** | any x64/x86 Linux machine | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 8.3.0, 9.2.0, 9.3.0 |
-| **Raspberry Pi GCC Native-Compiler Toolchains(Stretch)** | Raspbian Stretch OS (Debian Version 9) only | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 9.2.0, 9.3.0 |
-| **Raspberry Pi GCC Native-Compiler Toolchains(Buster)** | Raspbian Buster OS (Debian Version 10) only | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 9.2.0, 9.3.0 |
-| **Raspberry Pi GCC 64-Bit Cross-Compiler Toolchains** | any x64/x86 Linux machine | any x64 Raspberry Pi OS(like Pi64) | Stable/Production | 6.3.0, 8.3.0, 9.2.0, 9.3.0 |
-| **Raspberry Pi GCC 64-Bit Native-Compiler Toolchains** | any x64 Raspberry Pi OS(like Pi64) | any x64 Raspbian OS(like Pi64) | Stable/Production | 8.3.0, 9.2.0, 9.3.0 |
-| **Exclusive/Experimental Toolchains** |  None | None | Beta/Experimental | None | 
+| **Raspberry Pi GCC Cross-Compiler Toolchains(Stretch)** | any x64/x86 Linux machine | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 6.3.0,  9.2.0, 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC Cross-Compiler Toolchains(Buster)** | any x64/x86 Linux machine | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 8.3.0, 9.2.0, 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC Native-Compiler Toolchains(Stretch)** | Raspbian Stretch OS (Debian Version 9) only | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC Native-Compiler Toolchains(Buster)** | Raspbian Buster OS (Debian Version 10) only | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC 64-Bit Cross-Compiler Toolchains** | any x64/x86 Linux machine | any x64 Raspberry Pi OS(like Pi64) | Stable/Production | 6.3.0, 8.3.0, 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC 64-Bit Native-Compiler Toolchains** | any x64 Raspberry Pi OS(like Pi64) | any x64 Raspbian OS(like Pi64) | Stable/Production | 8.3.0, 9.3.0, 10.1.0 |
+| **Exclusive/Experimental Toolchains** |  None | None | Beta/Experimental | None |  
 
 
 **Tip:** _To get the location of each Binary of this project on SourceForge, you can also check out [this Reference Tree](https://github.com/abhiTronix/raspberry-pi-cross-compilers/wiki/Toolchain-Binaries-Reference-Tree#toolchain-binaries-reference-tree)._
@@ -160,11 +160,12 @@ These precompiled toolchains setup requires just three easy steps - **Downloadin
 
 **Here is a Bibtex entry you can use to cite this project in a publication:**
 
-```bibtex
+```BibTeX
 @misc{raspberry-pi-cross-compilers,
     Title = {Raspberry Pi Toolchains},
     Author = {Abhishek Thakur},
-    howpublished = {\url{https://github.com/abhiTronix/raspberry-pi-cross-compilers}}   
+    howpublished = {\url{https://github.com/abhiTronix/raspberry-pi-cross-compilers}},
+    year = {2020}  
   }
 ```
 

--- a/docs/gcc64.md
+++ b/docs/gcc64.md
@@ -70,12 +70,12 @@ This project now utilizes powerful [**Github Actions**][git-action] CI(Continuou
 
 | Toolchains | Host OS | Target OS | Current Status | Precompiled GCC versions available |
 | :---------- | :--------: | :-------: | :--------: | :------------------------: |
-| **Raspberry Pi GCC Cross-Compiler Toolchains(Stretch)** | any x64/x86 Linux machine | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 6.3.0,  9.2.0, 9.3.0 |
-| **Raspberry Pi GCC Cross-Compiler Toolchains(Buster)** | any x64/x86 Linux machine | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 8.3.0, 9.2.0, 9.3.0 |
-| **Raspberry Pi GCC Native-Compiler Toolchains(Stretch)** | Raspbian Stretch OS (Debian Version 9) only | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 9.2.0, 9.3.0 |
-| **Raspberry Pi GCC Native-Compiler Toolchains(Buster)** | Raspbian Buster OS (Debian Version 10) only | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 9.2.0, 9.3.0 |
-| **Raspberry Pi GCC 64-Bit Cross-Compiler Toolchains** | any x64/x86 Linux machine | any x64 Raspberry Pi OS(like Pi64) | Stable/Production | 6.3.0, 8.3.0, 9.2.0, 9.3.0 |
-| **Raspberry Pi GCC 64-Bit Native-Compiler Toolchains** | any x64 Raspberry Pi OS(like Pi64) | any x64 Raspbian OS(like Pi64) | Stable/Production | 8.3.0, 9.2.0, 9.3.0 |
+| **Raspberry Pi GCC Cross-Compiler Toolchains(Stretch)** | any x64/x86 Linux machine | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 6.3.0,  9.2.0, 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC Cross-Compiler Toolchains(Buster)** | any x64/x86 Linux machine | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 8.3.0, 9.2.0, 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC Native-Compiler Toolchains(Stretch)** | Raspbian Stretch OS (Debian Version 9) only | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC Native-Compiler Toolchains(Buster)** | Raspbian Buster OS (Debian Version 10) only | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC 64-Bit Cross-Compiler Toolchains** | any x64/x86 Linux machine | any x64 Raspberry Pi OS(like Pi64) | Stable/Production | 6.3.0, 8.3.0, 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC 64-Bit Native-Compiler Toolchains** | any x64 Raspberry Pi OS(like Pi64) | any x64 Raspbian OS(like Pi64) | Stable/Production | 8.3.0, 9.3.0, 10.1.0 |
 | **Exclusive/Experimental Toolchains** |  None | None | Beta/Experimental | None | 
 
 **Tip:** _To get the location of each Binary of this project on SourceForge, you can also check out [this Reference Tree](https://github.com/abhiTronix/raspberry-pi-cross-compilers/wiki/Toolchain-Binaries-Reference-Tree#toolchain-binaries-reference-tree)._
@@ -160,11 +160,12 @@ These precompiled toolchains setup requires just three easy steps - **Downloadin
 
 **Here is a Bibtex entry you can use to cite this project in a publication:**
 
-```bibtex
+```BibTeX
 @misc{raspberry-pi-cross-compilers,
     Title = {Raspberry Pi Toolchains},
     Author = {Abhishek Thakur},
-    howpublished = {\url{https://github.com/abhiTronix/raspberry-pi-cross-compilers}}   
+    howpublished = {\url{https://github.com/abhiTronix/raspberry-pi-cross-compilers}},
+    year = {2020}  
   }
 ```
 

--- a/docs/native-gcc-buster.md
+++ b/docs/native-gcc-buster.md
@@ -72,12 +72,12 @@ This project now utilizes powerful [**Github Actions**][git-action] CI(Continuou
 
 | Toolchains | Host OS | Target OS | Current Status | Precompiled GCC versions available |
 | :---------- | :--------: | :-------: | :--------: | :------------------------: |
-| **Raspberry Pi GCC Cross-Compiler Toolchains(Stretch)** | any x64/x86 Linux machine | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 6.3.0,  9.2.0, 9.3.0 |
-| **Raspberry Pi GCC Cross-Compiler Toolchains(Buster)** | any x64/x86 Linux machine | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 8.3.0, 9.2.0, 9.3.0 |
-| **Raspberry Pi GCC Native-Compiler Toolchains(Stretch)** | Raspbian Stretch OS (Debian Version 9) only | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 9.2.0, 9.3.0 |
-| **Raspberry Pi GCC Native-Compiler Toolchains(Buster)** | Raspbian Buster OS (Debian Version 10) only | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 9.2.0, 9.3.0 |
-| **Raspberry Pi GCC 64-Bit Cross-Compiler Toolchains** | any x64/x86 Linux machine | any x64 Raspberry Pi OS(like Pi64) | Stable/Production | 6.3.0, 8.3.0, 9.2.0, 9.3.0 |
-| **Raspberry Pi GCC 64-Bit Native-Compiler Toolchains** | any x64 Raspberry Pi OS(like Pi64) | any x64 Raspbian OS(like Pi64) | Stable/Production | 8.3.0, 9.2.0, 9.3.0 |
+| **Raspberry Pi GCC Cross-Compiler Toolchains(Stretch)** | any x64/x86 Linux machine | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 6.3.0,  9.2.0, 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC Cross-Compiler Toolchains(Buster)** | any x64/x86 Linux machine | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 8.3.0, 9.2.0, 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC Native-Compiler Toolchains(Stretch)** | Raspbian Stretch OS (Debian Version 9) only | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC Native-Compiler Toolchains(Buster)** | Raspbian Buster OS (Debian Version 10) only | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC 64-Bit Cross-Compiler Toolchains** | any x64/x86 Linux machine | any x64 Raspberry Pi OS(like Pi64) | Stable/Production | 6.3.0, 8.3.0, 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC 64-Bit Native-Compiler Toolchains** | any x64 Raspberry Pi OS(like Pi64) | any x64 Raspbian OS(like Pi64) | Stable/Production | 8.3.0, 9.3.0, 10.1.0 |
 | **Exclusive/Experimental Toolchains** |  None | None | Beta/Experimental | None | 
 
 
@@ -163,14 +163,14 @@ These precompiled toolchains setup requires just three easy steps - **Downloadin
 
 **Here is a Bibtex entry you can use to cite this project in a publication:**
 
-```bibtex
+```BibTeX
 @misc{raspberry-pi-cross-compilers,
     Title = {Raspberry Pi Toolchains},
     Author = {Abhishek Thakur},
-    howpublished = {\url{https://github.com/abhiTronix/raspberry-pi-cross-compilers}}   
+    howpublished = {\url{https://github.com/abhiTronix/raspberry-pi-cross-compilers}},
+    year = {2020}  
   }
 ```
-
 
 <br>
 

--- a/docs/native-gcc-stretch.md
+++ b/docs/native-gcc-stretch.md
@@ -70,13 +70,13 @@ This project now utilizes powerful [**Github Actions**][git-action] CI(Continuou
 
 | Toolchains | Host OS | Target OS | Current Status | Precompiled GCC versions available |
 | :---------- | :--------: | :-------: | :--------: | :------------------------: |
-| **Raspberry Pi GCC Cross-Compiler Toolchains(Stretch)** | any x64/x86 Linux machine | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 6.3.0,  9.2.0, 9.3.0 |
-| **Raspberry Pi GCC Cross-Compiler Toolchains(Buster)** | any x64/x86 Linux machine | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 8.3.0, 9.2.0, 9.3.0 |
-| **Raspberry Pi GCC Native-Compiler Toolchains(Stretch)** | Raspbian Stretch OS (Debian Version 9) only | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 9.2.0, 9.3.0 |
-| **Raspberry Pi GCC Native-Compiler Toolchains(Buster)** | Raspbian Buster OS (Debian Version 10) only | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 9.2.0, 9.3.0 |
-| **Raspberry Pi GCC 64-Bit Cross-Compiler Toolchains** | any x64/x86 Linux machine | any x64 Raspberry Pi OS(like Pi64) | Stable/Production | 6.3.0, 8.3.0, 9.2.0, 9.3.0 |
-| **Raspberry Pi GCC 64-Bit Native-Compiler Toolchains** | any x64 Raspberry Pi OS(like Pi64) | any x64 Raspbian OS(like Pi64) | Stable/Production | 8.3.0, 9.2.0, 9.3.0 |
-| **Exclusive/Experimental Toolchains** |  None | None | Beta/Experimental | None | 
+| **Raspberry Pi GCC Cross-Compiler Toolchains(Stretch)** | any x64/x86 Linux machine | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 6.3.0,  9.2.0, 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC Cross-Compiler Toolchains(Buster)** | any x64/x86 Linux machine | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 8.3.0, 9.2.0, 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC Native-Compiler Toolchains(Stretch)** | Raspbian Stretch OS (Debian Version 9) only | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC Native-Compiler Toolchains(Buster)** | Raspbian Buster OS (Debian Version 10) only | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC 64-Bit Cross-Compiler Toolchains** | any x64/x86 Linux machine | any x64 Raspberry Pi OS(like Pi64) | Stable/Production | 6.3.0, 8.3.0, 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC 64-Bit Native-Compiler Toolchains** | any x64 Raspberry Pi OS(like Pi64) | any x64 Raspbian OS(like Pi64) | Stable/Production | 8.3.0, 9.3.0, 10.1.0 |
+| **Exclusive/Experimental Toolchains** |  None | None | Beta/Experimental | None |  
  
 
 
@@ -162,11 +162,12 @@ These precompiled toolchains setup requires just three easy steps - **Downloadin
 
 **Here is a Bibtex entry you can use to cite this project in a publication:**
 
-```bibtex
+```BibTeX
 @misc{raspberry-pi-cross-compilers,
     Title = {Raspberry Pi Toolchains},
     Author = {Abhishek Thakur},
-    howpublished = {\url{https://github.com/abhiTronix/raspberry-pi-cross-compilers}}   
+    howpublished = {\url{https://github.com/abhiTronix/raspberry-pi-cross-compilers}},
+    year = {2020}  
   }
 ```
 

--- a/docs/native-gcc.md
+++ b/docs/native-gcc.md
@@ -69,13 +69,13 @@ This project now utilizes powerful [**Github Actions**][git-action] CI(Continuou
 
 | Toolchains | Host OS | Target OS | Current Status | Precompiled GCC versions available |
 | :---------- | :--------: | :-------: | :--------: | :------------------------: |
-| **Raspberry Pi GCC Cross-Compiler Toolchains(Stretch)** | any x64/x86 Linux machine | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 6.3.0,  9.2.0, 9.3.0 |
-| **Raspberry Pi GCC Cross-Compiler Toolchains(Buster)** | any x64/x86 Linux machine | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 8.3.0, 9.2.0, 9.3.0 |
-| **Raspberry Pi GCC Native-Compiler Toolchains(Stretch)** | Raspbian Stretch OS (Debian Version 9) only | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 9.2.0, 9.3.0 |
-| **Raspberry Pi GCC Native-Compiler Toolchains(Buster)** | Raspbian Buster OS (Debian Version 10) only | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 9.2.0, 9.3.0 |
-| **Raspberry Pi GCC 64-Bit Cross-Compiler Toolchains** | any x64/x86 Linux machine | any x64 Raspberry Pi OS(like Pi64) | Stable/Production | 6.3.0, 8.3.0, 9.2.0, 9.3.0 |
-| **Raspberry Pi GCC 64-Bit Native-Compiler Toolchains** | any x64 Raspberry Pi OS(like Pi64) | any x64 Raspbian OS(like Pi64) | Stable/Production | 8.3.0, 9.2.0, 9.3.0 |
-| **Exclusive/Experimental Toolchains** |  None | None | Beta/Experimental | None | 
+| **Raspberry Pi GCC Cross-Compiler Toolchains(Stretch)** | any x64/x86 Linux machine | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 6.3.0,  9.2.0, 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC Cross-Compiler Toolchains(Buster)** | any x64/x86 Linux machine | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 8.3.0, 9.2.0, 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC Native-Compiler Toolchains(Stretch)** | Raspbian Stretch OS (Debian Version 9) only | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC Native-Compiler Toolchains(Buster)** | Raspbian Buster OS (Debian Version 10) only | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC 64-Bit Cross-Compiler Toolchains** | any x64/x86 Linux machine | any x64 Raspberry Pi OS(like Pi64) | Stable/Production | 6.3.0, 8.3.0, 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC 64-Bit Native-Compiler Toolchains** | any x64 Raspberry Pi OS(like Pi64) | any x64 Raspbian OS(like Pi64) | Stable/Production | 8.3.0, 9.3.0, 10.1.0 |
+| **Exclusive/Experimental Toolchains** |  None | None | Beta/Experimental | None |  
  
 
 
@@ -160,11 +160,12 @@ These precompiled toolchains setup requires just three easy steps - **Downloadin
 
 **Here is a Bibtex entry you can use to cite this project in a publication:**
 
-```bibtex
+```BibTeX
 @misc{raspberry-pi-cross-compilers,
     Title = {Raspberry Pi Toolchains},
     Author = {Abhishek Thakur},
-    howpublished = {\url{https://github.com/abhiTronix/raspberry-pi-cross-compilers}}   
+    howpublished = {\url{https://github.com/abhiTronix/raspberry-pi-cross-compilers}},
+    year = {2020}  
   }
 ```
 

--- a/docs/native-gcc64.md
+++ b/docs/native-gcc64.md
@@ -70,12 +70,12 @@ This project now utilizes powerful [**Github Actions**][git-action] CI(Continuou
 
 | Toolchains | Host OS | Target OS | Current Status | Precompiled GCC versions available |
 | :---------- | :--------: | :-------: | :--------: | :------------------------: |
-| **Raspberry Pi GCC Cross-Compiler Toolchains(Stretch)** | any x64/x86 Linux machine | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 6.3.0,  9.2.0, 9.3.0 |
-| **Raspberry Pi GCC Cross-Compiler Toolchains(Buster)** | any x64/x86 Linux machine | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 8.3.0, 9.2.0, 9.3.0 |
-| **Raspberry Pi GCC Native-Compiler Toolchains(Stretch)** | Raspbian Stretch OS (Debian Version 9) only | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 9.2.0, 9.3.0 |
-| **Raspberry Pi GCC Native-Compiler Toolchains(Buster)** | Raspbian Buster OS (Debian Version 10) only | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 9.2.0, 9.3.0 |
-| **Raspberry Pi GCC 64-Bit Cross-Compiler Toolchains** | any x64/x86 Linux machine | any x64 Raspberry Pi OS(like Pi64) | Stable/Production | 6.3.0, 8.3.0, 9.2.0, 9.3.0 |
-| **Raspberry Pi GCC 64-Bit Native-Compiler Toolchains** | any x64 Raspberry Pi OS(like Pi64) | any x64 Raspbian OS(like Pi64) | Stable/Production | 8.3.0, 9.2.0, 9.3.0 |
+| **Raspberry Pi GCC Cross-Compiler Toolchains(Stretch)** | any x64/x86 Linux machine | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 6.3.0,  9.2.0, 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC Cross-Compiler Toolchains(Buster)** | any x64/x86 Linux machine | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 8.3.0, 9.2.0, 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC Native-Compiler Toolchains(Stretch)** | Raspbian Stretch OS (Debian Version 9) only | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC Native-Compiler Toolchains(Buster)** | Raspbian Buster OS (Debian Version 10) only | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC 64-Bit Cross-Compiler Toolchains** | any x64/x86 Linux machine | any x64 Raspberry Pi OS(like Pi64) | Stable/Production | 6.3.0, 8.3.0, 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC 64-Bit Native-Compiler Toolchains** | any x64 Raspberry Pi OS(like Pi64) | any x64 Raspbian OS(like Pi64) | Stable/Production | 8.3.0, 9.3.0, 10.1.0 |
 | **Exclusive/Experimental Toolchains** |  None | None | Beta/Experimental | None | 
 
 
@@ -161,11 +161,12 @@ These precompiled toolchains setup requires just three easy steps - **Downloadin
 
 **Here is a Bibtex entry you can use to cite this project in a publication:**
 
-```bibtex
+```BibTeX
 @misc{raspberry-pi-cross-compilers,
     Title = {Raspberry Pi Toolchains},
     Author = {Abhishek Thakur},
-    howpublished = {\url{https://github.com/abhiTronix/raspberry-pi-cross-compilers}}   
+    howpublished = {\url{https://github.com/abhiTronix/raspberry-pi-cross-compilers}},
+    year = {2020}  
   }
 ```
 


### PR DESCRIPTION
### Features

- Added new GCC v10.1.0 to build matrix. (fixes #40)
- Merged build jobs into compact form using GitHub Action strategy matrices. (fixes #41)
- Re-implemented & improved various jobs build logics.
- Updated CI Base Builder jobs to deploy on publishing.
- Added support for recently released GCC v8.4.0 in build scripts.
- Removed GCC v9.2.0 from Native 32-bit and all 64-bit build matrices(Soon be depreciated).
- Updated project docs with new changes.