### PR TITLE
Release new v3.0.3

### DIFF
--- a/.github/workflows/builder_0_1.yml
+++ b/.github/workflows/builder_0_1.yml
@@ -104,7 +104,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        gcc_versions: [6.3.0, 8.3.0, 9.2.0, 9.3.0, 10.1.0]
+        gcc_versions: [6.3.0, 8.3.0, 9.3.0, 10.2.0]
         rpios_types: [stretch, buster]
     env:
       GCC_VERSION: ${{ matrix.gcc_versions }}  
@@ -158,7 +158,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        gcc_versions: [9.3.0, 10.1.0]
+        gcc_versions: [9.3.0, 10.2.0]
         rpios_types: [stretch, buster]
     env:
       GCC_VERSION: ${{ matrix.gcc_versions }}  

--- a/.github/workflows/builder_2_3.yml
+++ b/.github/workflows/builder_2_3.yml
@@ -40,7 +40,7 @@ on:
 
 env:
   RPI_TYPE: 2-3
-  CURL_VERSION: 7.68.0
+  CURL_VERSION: 7.72.0
   CCACHE_COMPRESS: 1
   CCACHE_DIR: $HOME/.ccache
   USER_SFTP: ${{ secrets.USER_SFTP }}

--- a/.github/workflows/builder_2_3.yml
+++ b/.github/workflows/builder_2_3.yml
@@ -96,7 +96,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        gcc_versions: [6.3.0, 8.3.0, 9.2.0, 9.3.0, 10.1.0]
+        gcc_versions: [6.3.0, 8.3.0, 9.3.0, 10.2.0]
         rpios_types: [stretch, buster]
     env:
       GCC_VERSION: ${{ matrix.gcc_versions }}  
@@ -155,7 +155,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        gcc_versions: [9.3.0, 10.1.0]
+        gcc_versions: [9.3.0, 10.2.0]
         rpios_types: [stretch, buster]
     env:
       GCC_VERSION: ${{ matrix.gcc_versions }}  

--- a/.github/workflows/builder_3_plus.yml
+++ b/.github/workflows/builder_3_plus.yml
@@ -96,7 +96,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        gcc_versions: [6.3.0, 8.3.0, 9.2.0, 9.3.0, 10.1.0]
+        gcc_versions: [6.3.0, 8.3.0, 9.3.0, 10.2.0]
         rpios_types: [stretch, buster]
     env:
       GCC_VERSION: ${{ matrix.gcc_versions }}  
@@ -141,7 +141,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        gcc_versions: [9.3.0, 10.1.0]
+        gcc_versions: [9.3.0, 10.2.0]
         rpios_types: [stretch, buster]
     env:
       GCC_VERSION: ${{ matrix.gcc_versions }}  

--- a/.github/workflows/builder_3_plus.yml
+++ b/.github/workflows/builder_3_plus.yml
@@ -40,7 +40,7 @@ on:
 
 env:
   RPI_TYPE: 3+
-  CURL_VERSION: 7.68.0
+  CURL_VERSION: 7.72.0
   CCACHE_COMPRESS: 1
   CCACHE_DIR: $HOME/.ccache
   USER_SFTP: ${{ secrets.USER_SFTP }}

--- a/.github/workflows/builder_64.yml
+++ b/.github/workflows/builder_64.yml
@@ -40,7 +40,7 @@ on:
 
 env:
   RPI_TYPE: 64
-  CURL_VERSION: 7.68.0
+  CURL_VERSION: 7.72.0
   CCACHE_COMPRESS: 1
   CCACHE_DIR: $HOME/.ccache
   USER_SFTP: ${{ secrets.USER_SFTP }}

--- a/.github/workflows/builder_64.yml
+++ b/.github/workflows/builder_64.yml
@@ -105,7 +105,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        gcc_versions: [6.3.0, 8.3.0, 9.3.0, 10.1.0]
+        gcc_versions: [6.3.0, 8.3.0, 9.3.0, 10.2.0]
     env:
       GCC_VERSION: ${{ matrix.gcc_versions }}  
       COMPILER_TYPE: CROSS
@@ -156,7 +156,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        gcc_versions: [8.3.0, 9.3.0, 10.1.0]
+        gcc_versions: [8.3.0, 9.3.0, 10.2.0]
     env:
       GCC_VERSION: ${{ matrix.gcc_versions }}  
       COMPILER_TYPE: NATIVE

--- a/.github/workflows/builder_x86_64.yml
+++ b/.github/workflows/builder_x86_64.yml
@@ -112,8 +112,8 @@ jobs:
         run: |
           sudo apt-get update -qq
           sudo apt-get install -qq dos2unix -y
-          dos2unix build-scripts/CI/CINTB_64b 
-          chmod +x build-scripts/CI/CINTB_64b 
+          dos2unix build-scripts/CI/x86_64TB 
+          chmod +x build-scripts/CI/x86_64TB 
           dos2unix patches/curl_stfp_patcher
           chmod +x patches/curl_stfp_patcher
           dos2unix utils/SF_deployer
@@ -129,7 +129,7 @@ jobs:
           source ~/.bashrc && echo $PATH
         if: success()
       - name: script
-        run: bash build-scripts/CI/CINTB_64b -g $GCC_VERSION -t $OS_TYPE
+        run: bash build-scripts/CI/x86_64TB -g $GCC_VERSION -t $OS_TYPE
         shell: bash
         if: success()
       - name: before_script

--- a/.github/workflows/builder_x86_64.yml
+++ b/.github/workflows/builder_x86_64.yml
@@ -21,7 +21,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 # ===============================================
 
-name: CI Builder Pi[0-1] 
+name: CI Builder Pi[64] 
 
 on:
   # Trigger the workflow on push or pull request,
@@ -39,7 +39,6 @@ on:
       - master
 
 env:
-  RPI_TYPE: 0-1
   CURL_VERSION: 7.72.0
   CCACHE_COMPRESS: 1
   CCACHE_DIR: $HOME/.ccache
@@ -47,24 +46,23 @@ env:
   PASSWORD_SFTP: ${{ secrets.PASSWORD_SFTP }}
 
 jobs:
-  builder-base:
-    name: Base GCC 32-bit Builder Pi[0-1]
+  builder-x86_64:
+    name: GCC x86_64 Builder Pi[Desktop]
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rpios_types: [stretch, buster]
+        gcc_versions: [8.3.0, 9.3.0, 10.2.0]
     env:
-      RPIOS_TYPE: ${{ matrix.rpios_types }}
-      COMPILER_TYPE: CROSS
-      BASE: true
+      GCC_VERSION: ${{ matrix.gcc_versions }}  
+      OS_TYPE: x86_64
     steps:
       - uses: actions/checkout@v2
       - name: before_install
         run: |
           sudo apt-get update -qq
           sudo apt-get install -qq dos2unix -y
-          dos2unix build-scripts/CI/CIBB_32b 
-          chmod +x build-scripts/CI/CIBB_32b 
+          dos2unix build-scripts/CI/x86_64TB 
+          chmod +x build-scripts/CI/x86_64TB 
           dos2unix patches/curl_stfp_patcher
           chmod +x patches/curl_stfp_patcher
           dos2unix utils/SF_deployer
@@ -80,16 +78,17 @@ jobs:
           source ~/.bashrc && echo $PATH
         if: success()
       - name: script
-        run: bash build-scripts/CI/CIBB_32b -r $RPI_TYPE -o $RPIOS_TYPE
+        run: bash build-scripts/CI/x86_64TB -g $GCC_VERSION
         shell: bash
-        if: success() && (github.event_name == 'pull_request' || github.event_name == 'release')
+        if: success()
       - name: before_script
         run: bash patches/curl_stfp_patcher
         shell: bash
         if: success()
       - name: after_success
         run: |
-          cp docs/base-gcc.md $HOME/README.md
+          cp docs/desktop-gcc.md $HOME/root/README.md
+          cp docs/desktop-gcc-x86_64.md $HOME/README.md
           bash utils/SF_docs_deployer
         shell: bash
         if: success() && github.event_name == 'release'
@@ -98,26 +97,23 @@ jobs:
         shell: bash
         if: success() && github.event_name == 'release' && github.event.action == 'published'
 
-  builder-cross:
-    name: Cross GCC 32-bit Builder Pi[0-1]
-    needs: builder-base
+  builder-x86:
+    name: GCC x86 Builder Pi[Desktop]
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        gcc_versions: [6.3.0, 8.3.0, 9.2.0, 9.3.0, 10.1.0]
-        rpios_types: [stretch, buster]
+        gcc_versions: [8.3.0, 9.3.0, 10.2.0]
     env:
       GCC_VERSION: ${{ matrix.gcc_versions }}  
-      RPIOS_TYPE: ${{ matrix.rpios_types }} 
-      COMPILER_TYPE: CROSS
+      OS_TYPE: x86
     steps:
       - uses: actions/checkout@v2
       - name: before_install
         run: |
           sudo apt-get update -qq
           sudo apt-get install -qq dos2unix -y
-          dos2unix build-scripts/CI/CICTB_32b 
-          chmod +x build-scripts/CI/CICTB_32b 
+          dos2unix build-scripts/CI/CINTB_64b 
+          chmod +x build-scripts/CI/CINTB_64b 
           dos2unix patches/curl_stfp_patcher
           chmod +x patches/curl_stfp_patcher
           dos2unix utils/SF_deployer
@@ -133,7 +129,7 @@ jobs:
           source ~/.bashrc && echo $PATH
         if: success()
       - name: script
-        run: bash build-scripts/CI/CICTB_32b -g $GCC_VERSION -r $RPI_TYPE -o $RPIOS_TYPE
+        run: bash build-scripts/CI/CINTB_64b -g $GCC_VERSION -t $OS_TYPE
         shell: bash
         if: success()
       - name: before_script
@@ -142,62 +138,7 @@ jobs:
         if: success()
       - name: after_success
         run: |
-          mkdir -p $HOME/root
-          cp docs/cross-gcc.md $HOME/root/README.md
-          bash utils/SF_docs_deployer
-        shell: bash
-        if: success() && github.event_name == 'release'
-      - name: deploy
-        run: bash utils/SF_deployer
-        shell: bash
-        if: success() && github.event_name == 'release' && github.event.action == 'published'
-
-  builder-native:
-    name: Native GCC 32-bit Builder Pi[0-1]
-    needs: [builder-base, builder-cross]
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        gcc_versions: [9.3.0, 10.1.0]
-        rpios_types: [stretch, buster]
-    env:
-      GCC_VERSION: ${{ matrix.gcc_versions }}  
-      RPIOS_TYPE: ${{ matrix.rpios_types }}  
-      COMPILER_TYPE: NATIVE
-    steps:
-      - uses: actions/checkout@v2
-      - name: before_install
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -qq dos2unix -y
-          dos2unix build-scripts/CI/CINTB_32b 
-          chmod +x build-scripts/CI/CINTB_32b 
-          dos2unix patches/curl_stfp_patcher
-          chmod +x patches/curl_stfp_patcher
-          dos2unix utils/SF_deployer
-          chmod +x utils/SF_deployer
-          dos2unix utils/SF_docs_deployer
-          chmod +x utils/SF_docs_deployer
-        if: success()
-      - name: install
-        run: |
-          sudo apt-get -y install -qq gcc g++ gperf flex texinfo pigz gawk gfortran texinfo bison libncurses-dev ccache autoconf automake build-essential libssh2-1-dev openssl libcurl3 unzip wget
-          sudo /usr/sbin/update-ccache-symlinks
-          echo 'export PATH="/usr/lib/ccache:$PATH"' | tee -a ~/.bashrc
-          source ~/.bashrc && echo $PATH
-        if: success()
-      - name: script
-        run: bash build-scripts/CI/CINTB_32b -g $GCC_VERSION -r $RPI_TYPE -o $RPIOS_TYPE
-        shell: bash
-        if: success()
-      - name: before_script
-        run: bash patches/curl_stfp_patcher
-        shell: bash
-        if: success()
-      - name: after_success
-        run: |
-          mkdir -p $HOME/root
-          cp docs/native-gcc.md $HOME/root/README.md
+          cp docs/desktop-gcc-x86.md $HOME/README.md
           bash utils/SF_docs_deployer
         shell: bash
         if: success() && github.event_name == 'release'

--- a/.github/workflows/builder_x86_64.yml
+++ b/.github/workflows/builder_x86_64.yml
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        gcc_versions: [8.3.0, 9.3.0, 10.2.0]
+        gcc_versions: [10.2.0]
     env:
       GCC_VERSION: ${{ matrix.gcc_versions }}  
       OS_TYPE: x86_64
@@ -102,7 +102,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        gcc_versions: [8.3.0, 9.3.0, 10.2.0]
+        gcc_versions: [10.2.0]
     env:
       GCC_VERSION: ${{ matrix.gcc_versions }}  
       OS_TYPE: x86

--- a/.github/workflows/builder_x86_64.yml
+++ b/.github/workflows/builder_x86_64.yml
@@ -21,7 +21,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 # ===============================================
 
-name: CI Builder Pi[64] 
+name: CI Builder Pi[Desktop] 
 
 on:
   # Trigger the workflow on push or pull request,

--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 <table align="center"><tr><td align="center">
 <img alt="Raspberry Pi Toolchains Logo" src="https://raw.githubusercontent.com/abhiTronix/Imbakup/master/Images/gcc/GCC.png">
 
-<a align="center"> **Latest automated Build-scripts and CI maintained Precompiled Standalone (ARM/ARM64) Toolchains for Raspberry Pi**</a>
+<a align="center"> **Latest CI maintained Precompiled Standalone (ARM/ARM64) Toolchains for Raspberry Pi**</a>
 
 ![CI Builder Pi[0-1]](https://github.com/abhiTronix/raspberry-pi-cross-compilers/workflows/CI%20Builder%20Pi%5B0-1%5D/badge.svg)
 ![CI Builder Pi[2-3]](https://github.com/abhiTronix/raspberry-pi-cross-compilers/workflows/CI%20Builder%20Pi%5B2-3%5D/badge.svg)
 ![CI Builder Pi[3+]](https://github.com/abhiTronix/raspberry-pi-cross-compilers/workflows/CI%20Builder%20Pi%5B3+%5D/badge.svg)
 ![CI Builder Pi[64]](https://github.com/abhiTronix/raspberry-pi-cross-compilers/workflows/CI%20Builder%20Pi%5B64%5D/badge.svg)
-
+![CI Builder Pi[Desktop]](https://github.com/abhiTronix/raspberry-pi-cross-compilers/workflows/CI%20Builder%20Pi%5B64%5D/badge.svg)
 
 [![Open Source Love png1](https://badges.frapsoft.com/os/v1/open-source.png?v=103)](https://github.com/abhiTronix/raspberry-pi-cross-compilers)
 [![License][license-badge]][license]
@@ -58,7 +58,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
   * [**E. Toolchain Setup Documentation**](#e-toolchain-setup-documentation)
   * [**F. Supported Toolchains Programming Languages**](#f-supported-toolchains-programming-languages)
 * **For Developers: Do It Yourself**
-  * [**Build-Scripts**](#scroll-build-scripts)
+  * [**Build-Scripts**](#-3)
 * [**Supporting this Project :heart:**](#supporting-this-project)
 * [**Additional Information**](#additional-information)
   * [**Supported ARM Devices**](#supported-arm-devices)
@@ -76,11 +76,11 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 **What is this project?**
 
-> _This project provides the latest, CI maintained, precompiled [**Raspberry Pi CPU optimized**](#optimization-flags-involved) GCC Cross & Native (ARM & ARM64) Compressed Standalone Toolchains, that is [**fastest to setup**](#e-toolchain-setup-documentation) and saves you tons of time and thereby helps you to get quickly started with software development with Pi._
+> _This project provides the latest, CI maintained, precompiled [**Raspberry Pi CPU optimized**](#optimization-flags-involved) GCC Cross & Native (ARM & ARM64) Compressed Standalone Toolchains, that is [**fastest to setup**](#e-toolchain-setup-documentation) and saves you tons of time and thereby helps you to get quickly started with software development on Raspberry Pi._
 
 **Who will benefit from the project?**
 
-> _This project benefits everyone, from a professional Developer to a small Hobbyist to a research Student, who's looking for latest easy-to-use precompiled GCC toolchains for their Raspberry Pi project(s)._ 
+> _This project benefits everyone, from Devs to a small Hobbyist to a research Student, who's looking for latest easy-to-use precompiled GCC toolchains for their Raspberry Pi project(s)._ 
 
 
 &nbsp;
@@ -90,13 +90,13 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 ### New v3.0+ Release SneekPeak
 
 - *Automated CI maintained GCC standalone ARM/ARM64 toolchains.*
-- *Latest [**GCC 10.1.0**](https://gcc.gnu.org/gcc-10/) toolchains available.*<img src="https://raw.githubusercontent.com/abhiTronix/Imbakup/master/Images/new.gif"/>
+- *Latest [**GCC 10.2.0**](https://gcc.gnu.org/gcc-10/) toolchains available.*<img src="https://raw.githubusercontent.com/abhiTronix/Imbakup/master/Images/new.gif"/>
 - *Hardcoded paths free both Cross & Native **Raspbian Buster (Debian 10)** toolchains available.*
 - *Separate binaries for each Raspberry Pi variant (including latest Compute modules and Raspberry Pi 4).*
 - *Tar Compressed binaries with maximum possible compression.*
 - *Exclusive **ARM64|AARCH64** Binaries for Raspberry Pi 64-Bit kernel OS flavors.*
 - *Open-sourced Toolchains build-scripts are also available.*
-- *Latest [**GDB Debugger v9.1**](https://www.gnu.org/software/gdb/download/ANNOUNCEMENT) included in all binaries.*<img src="https://raw.githubusercontent.com/abhiTronix/Imbakup/master/Images/new.gif"/>
+- *Latest [**GDB Debugger v9.2**](https://www.gnu.org/software/gdb/download/ANNOUNCEMENT) included in all binaries.*<img src="https://raw.githubusercontent.com/abhiTronix/Imbakup/master/Images/new.gif"/>
 
 
 &nbsp;
@@ -128,13 +128,13 @@ This project now utilizes powerful [**Github Actions**][git-action] CI(Continuou
 
 | Toolchains | Host OS | Target OS | Current Status | Precompiled GCC versions available |
 | :---------- | :--------: | :-------: | :--------: | :------------------------: |
-| **Raspberry Pi GCC Cross-Compiler Toolchains(Stretch)** | any x64/x86 Linux machine | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 6.3.0,  9.2.0, 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC Cross-Compiler Toolchains(Buster)** | any x64/x86 Linux machine | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 8.3.0, 9.2.0, 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC Native-Compiler Toolchains(Stretch)** | Raspbian Stretch OS (Debian Version 9) only | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC Native-Compiler Toolchains(Buster)** | Raspbian Buster OS (Debian Version 10) only | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC 64-Bit Cross-Compiler Toolchains** | any x64/x86 Linux machine | any x64 Raspberry Pi OS(like Pi64) | Stable/Production | 6.3.0, 8.3.0, 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC 64-Bit Native-Compiler Toolchains** | any x64 Raspberry Pi OS(like Pi64) | any x64 Raspbian OS(like Pi64) | Stable/Production | 8.3.0, 9.3.0, 10.1.0 |
-| **Exclusive/Experimental Toolchains** |  None | None | Beta/Experimental | None | 
+| **Raspberry Pi GCC Cross-Compiler Toolchains(Stretch)** | any x64/x86 Linux machine | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 6.3.0,  9.3.0, 10.2.0 |
+| **Raspberry Pi GCC Cross-Compiler Toolchains(Buster)** | any x64/x86 Linux machine | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 8.3.0, 9.3.0, 10.2.0 |
+| **Raspberry Pi GCC Native-Compiler Toolchains(Stretch)** | Raspbian Stretch OS (Debian Version 9) only | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 9.3.0, 10.2.0 |
+| **Raspberry Pi GCC Native-Compiler Toolchains(Buster)** | Raspbian Buster OS (Debian Version 10) only | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 9.3.0, 10.2.0 |
+| **Raspberry Pi GCC 64-Bit Cross-Compiler Toolchains** | any x64/x86 Linux machine | any x64 Raspberry Pi OS(like Pi64) | Stable/Production | 6.3.0, 8.3.0, 9.3.0, 10.2.0 |
+| **Raspberry Pi GCC 64-Bit Native-Compiler Toolchains** | any x64 Raspberry Pi OS(like Pi64) | any x64 Raspbian OS(like Pi64) | Stable/Production | 8.3.0, 9.3.0, 10.2.0 |
+| **Exclusive/Experimental Toolchains** |  x86/x86_64 Pi Desktop | x86/x86_64 Pi Desktop | Beta/Experimental | 10.2.0 | 
 
 
 &nbsp;
@@ -153,13 +153,13 @@ You can easily identify each pre-compiled toolchain binary by its name as follow
 
 | Toolchains Binaries | Status | GCC versions |
 | ---------- | -------- | :------: |
-| **Raspberry Pi GCC Cross-Compiler Toolchains(Stretch)**  | Stable/Production | [6.3.0][cc-stretch-630], [9.2.0][cc-stretch-920], [9.3.0][cc-stretch-930], [10.1.0][cc-stretch-1010] |
-| **Raspberry Pi GCC Cross-Compiler Toolchains(Buster)** | Stable/Production | [8.3.0][cc-buster-830], [9.2.0][cc-buster-920], [9.3.0][cc-buster-930], [10.1.0][cc-buster-1010] |
-| **Raspberry Pi GCC Native-Compiler Toolchains(Stretch)** | Stable/Production | [9.3.0][nc-stretch-930], [10.1.0][nc-stretch-1010] |
-| **Raspberry Pi GCC Native-Compiler Toolchains(Buster)** | Stable/Production | [9.3.0][nc-buster-930], [10.1.0][nc-buster-1010] |
-| **Raspberry Pi GCC 64-Bit Cross-Compiler Toolchains** | Stable/Production | [6.3.0][cc-64-630], [8.3.0][cc-64-830], [9.3.0][cc-64-930], [10.1.0][cc-64-1010]|
-| **Raspberry Pi GCC 64-Bit Native-Compiler Toolchains** | Stable/Production | [8.3.0][nc-64-830], [9.3.0][nc-64-930], [10.1.0][nc-64-1010] |
-| **Exclusive/Experimental Toolchains** |  Beta/Experimental | None |  
+| **Raspberry Pi GCC Cross-Compiler Toolchains(Stretch)**  | Stable/Production | [6.3.0][cc-stretch-630], [9.3.0][cc-stretch-930], [10.2.0][cc-stretch-1020] |
+| **Raspberry Pi GCC Cross-Compiler Toolchains(Buster)** | Stable/Production | [8.3.0][cc-buster-830], [9.3.0][cc-buster-930], [10.2.0][cc-buster-1020] |
+| **Raspberry Pi GCC Native-Compiler Toolchains(Stretch)** | Stable/Production | [9.3.0][nc-stretch-930], [10.2.0][nc-stretch-1020] |
+| **Raspberry Pi GCC Native-Compiler Toolchains(Buster)** | Stable/Production | [9.3.0][nc-buster-930], [10.2.0][nc-buster-1020] |
+| **Raspberry Pi GCC 64-Bit Cross-Compiler Toolchains** | Stable/Production | [6.3.0][cc-64-630], [8.3.0][cc-64-830], [9.3.0][cc-64-930], [10.2.0][cc-64-1020]|
+| **Raspberry Pi GCC 64-Bit Native-Compiler Toolchains** | Stable/Production | [8.3.0][nc-64-830], [9.3.0][nc-64-930], [10.2.0][nc-64-1020] |
+| **Exclusive/Experimental Toolchains** |  Beta/Experimental | [10.2.0 (x86)][dc-x86-1020], [10.2.0 (x86_64)][dc-x86_64-1020] |  
 
 
 **Tip::bulb:** _To get the location of each Binary of this project on SourceForge, you can also check out <a href = https://github.com/abhiTronix/raspberry-pi-cross-compilers/wiki/Toolchain-Binaries-Reference-Tree#toolchain-binaries-reference-tree>this Reference Tree</a>._
@@ -180,7 +180,7 @@ These precompiled toolchains setup requires just three easy steps - **Downloadin
 - C++
 - Fortran
 - C
-- Any other language support can be easily [compiled](#scroll-build-scripts).
+- Any other language support can be easily [compiled](#-3).
  
 &nbsp;
 
@@ -195,9 +195,7 @@ _Open-Source is awesome :heart:_
 
 - If you need additional language support or need to compile another suitable GCC version toolchains for your Raspberry Pi, then you can use these scripts to manually compile any GCC toolchains by running suitable build-scripts yourself through your system terminal.
 
-- **You can find complete information about these build-scripts here:**
-
-### :scroll: [Build-Scripts](/build-scripts)
+**You can find complete information about these build-scripts [here](/build-scripts)**
 
 
 &nbsp;
@@ -299,21 +297,23 @@ Thank you,
 [pigz]:https://zlib.net/pigz/
 
 [cc-stretch-630]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Stretch/GCC%206.3.0/
-[cc-stretch-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Stretch/GCC%209.2.0/
+
 [cc-stretch-930]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Stretch/GCC%209.3.0/
-[cc-stretch-1010]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Stretch/GCC%2010.1.0/
+[cc-stretch-1020]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Stretch/GCC%2010.2.0/
 [cc-buster-830]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Buster/GCC%208.3.0/
-[cc-buster-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Buster/GCC%209.2.0/
+
 [cc-buster-930]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Buster/GCC%209.3.0/
-[cc-buster-1010]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Buster/GCC%2010.1.0/
-[nc-stretch-1010]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Native-Compiler%20Toolchains/Stretch/GCC%2010.1.0/
-[nc-buster-1010]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Native-Compiler%20Toolchains/Buster/GCC%2010.1.0/
+[cc-buster-1020]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Buster/GCC%2010.2.0/
+[nc-stretch-1020]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Native-Compiler%20Toolchains/Stretch/GCC%2010.2.0/
+[nc-buster-1020]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Native-Compiler%20Toolchains/Buster/GCC%2010.2.0/
 [nc-stretch-930]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Native-Compiler%20Toolchains/Stretch/GCC%209.3.0/
 [nc-buster-930]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Native-Compiler%20Toolchains/Buster/GCC%209.3.0/
 [cc-64-630]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Bonus%20Raspberry%20Pi%20GCC%2064-Bit%20Toolchains/Raspberry%20Pi%20GCC%2064-Bit%20Cross-Compiler%20Toolchains/GCC%206.3.0/
 [cc-64-830]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Bonus%20Raspberry%20Pi%20GCC%2064-Bit%20Toolchains/Raspberry%20Pi%20GCC%2064-Bit%20Cross-Compiler%20Toolchains/GCC%208.3.0/
-[cc-64-1010]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Bonus%20Raspberry%20Pi%20GCC%2064-Bit%20Toolchains/Raspberry%20Pi%20GCC%2064-Bit%20Cross-Compiler%20Toolchains/GCC%2010.1.0/
+[cc-64-1020]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Bonus%20Raspberry%20Pi%20GCC%2064-Bit%20Toolchains/Raspberry%20Pi%20GCC%2064-Bit%20Cross-Compiler%20Toolchains/GCC%2010.2.0/
 [cc-64-930]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Bonus%20Raspberry%20Pi%20GCC%2064-Bit%20Toolchains/Raspberry%20Pi%20GCC%2064-Bit%20Cross-Compiler%20Toolchains/GCC%209.3.0/
 [nc-64-830]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Bonus%20Raspberry%20Pi%20GCC%2064-Bit%20Toolchains/Raspberry%20Pi%20GCC%2064-Bit%20Native-Compiler%20Toolchains/GCC%208.3.0/
-[nc-64-1010]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Bonus%20Raspberry%20Pi%20GCC%2064-Bit%20Toolchains/Raspberry%20Pi%20GCC%2064-Bit%20Native-Compiler%20Toolchains/GCC%2010.1.0/
+[nc-64-1020]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Bonus%20Raspberry%20Pi%20GCC%2064-Bit%20Toolchains/Raspberry%20Pi%20GCC%2064-Bit%20Native-Compiler%20Toolchains/GCC%2010.2.0/
 [nc-64-930]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Bonus%20Raspberry%20Pi%20GCC%2064-Bit%20Toolchains/Raspberry%20Pi%20GCC%2064-Bit%20Native-Compiler%20Toolchains/GCC%209.3.0/
+[dc-x86-1020]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Bonus%20Raspberry%20Pi%20GCC%2064-Bit%20Toolchains/Raspberry%20Pi%20GCC%2064-Bit%20Native-Compiler%20Toolchains/GCC%209.3.0/
+[dc-x86_64-1020]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Bonus%20Raspberry%20Pi%20GCC%2064-Bit%20Toolchains/Raspberry%20Pi%20GCC%2064-Bit%20Native-Compiler%20Toolchains/GCC%209.3.0/

--- a/build-scripts/CI/CIBB_32b
+++ b/build-scripts/CI/CIBB_32b
@@ -117,7 +117,7 @@ fi
 
 #pre-defined params
 TARGET=arm-linux-gnueabihf
-GDB_VERSION=9.1
+GDB_VERSION=9.2
 
 #validate env variables
 if ! [[ "$GCC_VERSION" =~ ^(6.3.0|8.3.0)$ ]]; then exit 1 ; fi

--- a/build-scripts/CI/CIBB_64b
+++ b/build-scripts/CI/CIBB_64b
@@ -102,7 +102,7 @@ FOLDER_VERSION=64
 KERNEL=kernel7
 ARCH=armv8-a+fp+simd
 TARGET=aarch64-linux-gnu
-GDB_VERSION=9.1
+GDB_VERSION=9.2
 
 
 #validate env variables

--- a/build-scripts/CI/CICTB_32b
+++ b/build-scripts/CI/CICTB_32b
@@ -42,7 +42,7 @@ helpfunction()
    echo ""
    echo ""
    echo "Usage: $0 -g [GCC version] -r [Target Pi type] -o [Target Pi OS type]"
-   echo -e "\t-g GCC version you want to compile?: (7.1.0|7.2.0|7.3.0|7.4.0|7.5.0|8.1.0|8.2.0|8.3.0|8.4.0|9.1.0|9.2.0|9.3.0|10.1.0)"
+   echo -e "\t-g GCC version you want to compile?: (7.1.0|7.2.0|7.3.0|7.4.0|7.5.0|8.1.0|8.2.0|8.3.0|8.4.0|9.1.0|9.2.0|9.3.0|10.1.0|10.2.0)"
    echo -e "\t-r What's yours Target Raspberry Pi type?: (0-1|2-3|3+)"
    echo -e "\t-o What's yours Target Raspberry Pi OS type?: (stretch|buster)"
    echo ""
@@ -125,7 +125,7 @@ fi
 
 #pre-defined params
 TARGET=arm-linux-gnueabihf
-GDB_VERSION=9.1
+GDB_VERSION=9.2
 
 #validate env variables
 if ! [[ "$GCCBASE_VERSION" =~ ^(6.3.0|8.3.0)$ ]]; then exit 1 ; fi

--- a/build-scripts/CI/CICTB_64b
+++ b/build-scripts/CI/CICTB_64b
@@ -100,7 +100,7 @@ fi
 FOLDER_VERSION=64
 ARCH=armv8-a+fp+simd
 TARGET=aarch64-linux-gnu
-GDB_VERSION=9.1
+GDB_VERSION=9.2
 
 
 #validate env variables

--- a/build-scripts/CI/CINTB_32b
+++ b/build-scripts/CI/CINTB_32b
@@ -42,7 +42,7 @@ helpfunction()
    echo ""
    echo ""
    echo "Usage: $0 -g [GCC version] -r [Target Pi type] -o [Target Pi OS type]"
-   echo -e "\t-g GCC version you want to compile?: (7.1.0|7.2.0|7.3.0|7.4.0|7.5.0|8.1.0|8.2.0|8.3.0|8.4.0|9.1.0|9.2.0|9.3.0|10.1.0)"
+   echo -e "\t-g GCC version you want to compile?: (7.1.0|7.2.0|7.3.0|7.4.0|7.5.0|8.1.0|8.2.0|8.3.0|8.4.0|9.1.0|9.2.0|9.3.0|10.1.0|10.2.0)"
    echo -e "\t-r What's yours Target Raspberry Pi type?: (0-1|2-3|3+)"
    echo -e "\t-o What's yours Target Raspberry Pi OS type?: (stretch|buster)"
    echo ""
@@ -113,7 +113,7 @@ fi
 
 #pre-defined params
 TARGET=arm-linux-gnueabihf
-GDB_VERSION=9.1
+GDB_VERSION=9.2
 
 #validate env variables
 if ! [[ "$FOLDER_VERSION" =~ ^(0|1|2)$ ]]; then exit 1 ; fi

--- a/build-scripts/CI/CINTB_64b
+++ b/build-scripts/CI/CINTB_64b
@@ -89,7 +89,7 @@ fi
 FOLDER_VERSION=64
 ARCH=armv8-a+fp+simd
 TARGET=aarch64-linux-gnu
-GDB_VERSION=9.1
+GDB_VERSION=9.2
 
 
 #validate env variables

--- a/build-scripts/CI/README.md
+++ b/build-scripts/CI/README.md
@@ -65,6 +65,10 @@ A generalized workflow used to generate and deploy these CI maintained toolchain
 
 * This build-script is used in CI to generate Compressed Native ARM64 Toolchain binaries targeting Raspberry Pi 64-bit OSes from respective Cross-Compiler Toolchain Binaries builds.
 
+### G. `x86_64TB`: Raspberry Pi CI Toolchains x86_64-Compiler Builder
+
+* This build-script is used in CI to generate Compressed x86_64/x86 Toolchain binaries targeting Raspberry Pi Desktop OSes from scratch.
+
 
 &nbsp;
 
@@ -88,6 +92,7 @@ These CI build-scripts supports newer as well as base GCC versions, those are as
 - 9.2.0
 - 9.3.0
 - 10.1.0
+- 10.2.0
 
 &nbsp;
 

--- a/build-scripts/CI/README.md
+++ b/build-scripts/CI/README.md
@@ -91,7 +91,7 @@ These CI build-scripts supports newer as well as base GCC versions, those are as
 - 8.3.0
 - 9.2.0
 - 9.3.0
-- 10.1.0
+- 10.2.0
 - 10.2.0
 
 &nbsp;

--- a/build-scripts/CI/x86_64TB
+++ b/build-scripts/CI/x86_64TB
@@ -41,7 +41,7 @@ helpfunction()
    echo ""
    echo ""
    echo "Usage: $0 -g [GCC version] -t [Target OS type]"
-   echo -e "\t-g GCC version you want to compile?: (7.1.0|7.2.0|7.3.0|7.4.0|7.5.0|8.1.0|8.2.0|8.3.0|9.1.0|9.2.0|9.3.0|10.1.0|10.2.0)"
+   echo -e "\t-g GCC version you want to compile?: (8.3.0|9.1.0|9.2.0|9.3.0|10.1.0|10.2.0)"
    echo -e "\t-t What's yours Target OS type?: (x86|x86_64) [default:x86_64]"
    echo ""
    echo ""
@@ -85,8 +85,10 @@ fi
 if ! [[ "$OS_TYPE" =~ ^("x86"|"x86_64")$ ]]; then exit 1 ; fi
 
 if [ "$OS_TYPE" = "x86_64" ]; then
-	ARCH=x86_64
+	ARCH_LINUX=x86_64
+	ARCH=x86-64
 else
+	ARCH_LINUX=i386
 	ARCH=i386
 fi
 
@@ -96,7 +98,7 @@ if echo ${GCC_VERSION%.*} "8.3" | awk '{exit ( $1 >= $2 )}'; then
 fi
 
 #pre-defined params
-TARGET=$ARCH-debian-linux
+TARGET=$ARCH_LINUX-pc-linux
 FOLDER_VERSION=$OS_TYPE
 GLIBC_VERSION=2.28
 BINUTILS_VERSION=2.31
@@ -180,9 +182,8 @@ unset LD_LIBRARY_PATH #patch
 
 echo "Building Kernel Headers..."
 cd "$DOWNLOADDIR"/linux || exit
-make -s ARCH=$ARCH INSTALL_HDR_PATH="$SYSROOTDIR"/usr headers_install
+make -s ARCH=$ARCH_LINUX INSTALL_HDR_PATH="$SYSROOTDIR"/usr headers_install
 mkdir -p "$SYSROOTDIR"/usr/lib
-
 
 echo "Building binutils..."
 if [ -n "$(ls -A "$DOWNLOADDIR"/binutils-$BINUTILS_VERSION/build)" ]; then rm -rf "$DOWNLOADDIR"/binutils-$BINUTILS_VERSION/build/*; fi

--- a/build-scripts/CI/x86_64TB
+++ b/build-scripts/CI/x86_64TB
@@ -3,7 +3,7 @@
 
 # ===============================================
 # Raspberry Pi Toolchains(raspberry-pi-cross-compilers): This project 
-# provides latest automated GCC Cross Compiler & Native (ARM & ARM64) 
+# provides latest automated GCC Cross Compiler & (ARM & ARM64) 
 # build-scripts and precompiled standalone toolchains for Raspberry Pi.
 
 
@@ -26,7 +26,7 @@
 
 
 
-# This script aauto downloads, compiles, and compresses Cross & Native GCC ARM64 Toolchain 
+# This script aauto downloads, compiles, and compresses Cross & GCC ARM64 Toolchain 
 # binaries targeting any Raspberry Pi 64-bit (like Pi64) OSes.
 
 
@@ -35,20 +35,18 @@ helpfunction()
    #helper function that prints custom usage help menu
    echo ""
    echo ""
-   figlet -t -k -f /usr/share/figlet/standard.flf "CLI Raspberry Pi Native Toolchains Builder 64-bit"
+   figlet -t -k -f /usr/share/figlet/standard.flf "CLI Raspberry Pi x86_64 Toolchains Builder"
    echo ""
    figlet -t -k -f /usr/share/figlet/term.flf "Copyright (c) 2020 abhiTronix"
    echo ""
    echo ""
    echo "Usage: $0 -g [GCC version] -t [Target OS type]"
    echo -e "\t-g GCC version you want to compile?: (7.1.0|7.2.0|7.3.0|7.4.0|7.5.0|8.1.0|8.2.0|8.3.0|9.1.0|9.2.0|9.3.0|10.1.0|10.2.0)"
-   echo -e "\t-t What's yours Target OS type?: (1|2) [default:1]"
+   echo -e "\t-t What's yours Target OS type?: (x86|x86_64) [default:x86_64]"
    echo ""
    echo ""
    exit 1 # Exits script after printing help
 }
-
-
 
 #input arguments handler
 while getopts "g:t:" opt
@@ -64,7 +62,7 @@ if [ -z "$GCC_VERSION" ]; then
    echo "Error: Required parameter is missing!";
    helpfunction
 elif [ -z "$OS_TYPE" ]; then
-	OS_TYPE=1
+	OS_TYPE=x86_64
 else
 	echo "Parameters configured!";
 fi
@@ -84,37 +82,38 @@ if [ "$LANGUAGES" = "" ]; then
 	LANGUAGES=c,c++,fortran
 fi
 
+if ! [[ "$OS_TYPE" =~ ^("x86"|"x86_64")$ ]]; then exit 1 ; fi
+
+if [ "$OS_TYPE" = "x86_64" ]; then
+	ARCH=x86-64
+	OPTS=-m64
+else
+	ARCH=i386
+	OPTS=-m32
+fi
+
+if echo ${GCC_VERSION%.*} "8.3" | awk '{exit ( $1 >= $2 )}'; then
+    echo "$GCC_VERSION is not supported!"
+	exit 0
+fi
 
 #pre-defined params
-FOLDER_VERSION=64
-ARCH=armv8-a+fp+simd
-TARGET=aarch64-linux-gnu
+TARGET=x86_64-linux-gnu
+FOLDER_VERSION=$OS_TYPE
 GDB_VERSION=9.1
 
-
 #validate env variables
-if [ "$ARCH" != "armv8-a+fp+simd" ]; then exit 1 ; fi
-if [ "$FOLDER_VERSION" != "64" ]; then exit 1 ; fi
 if [ "$BUILDDIR" = "" ]; then exit 1 ; fi
 if [ "$LANGUAGES" = "" ]; then exit 1 ; fi
-
-URL="https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Bonus%20Raspberry%20Pi%20GCC%2064-Bit%20Toolchains/Raspberry%20Pi%20GCC%2064-Bit%20Cross-Compiler%20Toolchains"
-if [ "$RPI_TYPE" = "64" ]; then URL="$URL/GCC%20$GCC_VERSION/"; fi
+if [ "$OPTS" = "" ]; then exit 1 ; fi
 
 echo "Downloading and Setting up build directories"
 #setup paths
 DOWNLOADDIR=$BUILDDIR/build_toolchains
 mkdir -p "$DOWNLOADDIR"
-
 cd "$DOWNLOADDIR" || exit
 
 #download binaries if not found
-if [ ! -f "cross-gcc-$GCC_VERSION-pi_$RPI_TYPE.tar.gz" ]; then 
-	wget -q "${URL}cross-gcc-$GCC_VERSION-pi_$RPI_TYPE.tar.gz"
-	tar xf cross-gcc-$GCC_VERSION-pi_$RPI_TYPE.tar.gz
-	mv cross-pi-gcc-$GCC_VERSION-$FOLDER_VERSION $BUILDDIR
-	rm ./*.tar.*
-fi
 if [ ! -d "gdb-$GDB_VERSION" ]; then
 	if [ ! -f "gdb-$GDB_VERSION.tar.xz" ]; then 
 		wget -q https://ftp.gnu.org/gnu/gdb/gdb-$GDB_VERSION.tar.xz; 
@@ -140,34 +139,32 @@ if [ ! -d "gcc-$GCC_VERSION" ]; then
 fi
 
 echo "Setting up paths..."
-PATH=$BUILDDIR/cross-pi-gcc-$GCC_VERSION-$FOLDER_VERSION/bin:$PATH
-unset LD_LIBRARY_PATH #patch
 
-echo "Building GCC Native GCC $GCC_VERSION Binaries..."
-mkdir -p "$BUILDDIR"/native-pi-gcc-"$GCC_VERSION"-$FOLDER_VERSION
+echo "Building GCC $GCC_VERSION Binaries..."
+mkdir -p "$BUILDDIR"/pi-gcc-"$GCC_VERSION"-$FOLDER_VERSION
 cd "$DOWNLOADDIR"/gcc-"$GCC_VERSION"/build || exit
 if [ -n "$(ls -A "$DOWNLOADDIR"/gcc-"$GCC_VERSION"/build)" ]; then rm -rf "$DOWNLOADDIR"/gcc-"$GCC_VERSION"/build/*; fi
-../configure --prefix= --build="$MACHTYPE" --host=$TARGET --target=$TARGET --enable-languages=$LANGUAGES --with-arch=$ARCH    --disable-multilib --program-suffix=-"$GCC_VERSION"
+../configure --prefix= --build="$MACHTYPE" --host=$TARGET --target=$TARGET --enable-languages=$LANGUAGES --with-arch=$ARCH  $OPTS  --disable-multilib --program-suffix=-"$GCC_VERSION"
 make -s -j$(nproc)
-make -s install-strip DESTDIR="$BUILDDIR"/native-pi-gcc-"$GCC_VERSION"-$FOLDER_VERSION
+make -s install-strip DESTDIR="$BUILDDIR"/pi-gcc-"$GCC_VERSION"-$FOLDER_VERSION
 if [ -n "$(ls -A "$DOWNLOADDIR"/gcc-"$GCC_VERSION"/build)" ]; then rm -rf "$DOWNLOADDIR"/gcc-"$GCC_VERSION"/build/*; fi
 cd "$DOWNLOADDIR"/gcc-"$GCC_VERSION" || exit
-cat gcc/limitx.h gcc/glimits.h gcc/limity.h > "$BUILDDIR"/native-pi-gcc-"$GCC_VERSION"-$FOLDER_VERSION/lib/gcc/$TARGET/"$GCC_VERSION"/include-fixed/limits.h
+cat gcc/limitx.h gcc/glimits.h gcc/limity.h > "$BUILDDIR"/pi-gcc-"$GCC_VERSION"-$FOLDER_VERSION/lib/gcc/$TARGET/"$GCC_VERSION"/include-fixed/limits.h
 
-echo "Building Native GDB Binaries..."
+echo "Building GDB Binaries..."
 cd "$DOWNLOADDIR"/gdb-$GDB_VERSION/build || exit
 if [ -n "$(ls -A "$DOWNLOADDIR"/gdb-$GDB_VERSION/build)" ]; then rm -rf "$DOWNLOADDIR"/gdb-$GDB_VERSION/build/*; fi
-../configure --prefix= --build="$MACHTYPE" --host=$TARGET --target=$TARGET --with-arch=$ARCH  --program-suffix=-"$GCC_VERSION"
+../configure --prefix= --build="$MACHTYPE" --host=$TARGET --target=$TARGET --with-arch=$ARCH  $OPTS --program-suffix=-"$GCC_VERSION"
 make -s -j$(nproc)
-make -s install DESTDIR="$BUILDDIR"/native-pi-gcc-"$GCC_VERSION"-$FOLDER_VERSION
+make -s install DESTDIR="$BUILDDIR"/pi-gcc-"$GCC_VERSION"-$FOLDER_VERSION
 if [ -n "$(ls -A "$DOWNLOADDIR"/gdb-$GDB_VERSION/build)" ]; then rm -rf "$DOWNLOADDIR"/gdb-$GDB_VERSION/build/*; fi
-echo "Done Building Native GDB Binaries..."
+echo "Done Building GDB Binaries..."
 
-mv "$BUILDDIR"/native-pi-gcc-"$GCC_VERSION"-$FOLDER_VERSION "$HOME"
+mv "$BUILDDIR"/pi-gcc-"$GCC_VERSION"-$FOLDER_VERSION "$HOME"
 cd "$HOME" || exit
 #compress with maximum possible compression level.
-tar cf - native-pi-gcc-"$GCC_VERSION"-$FOLDER_VERSION | pigz -9 -p 32 > native-gcc-"$GCC_VERSION"-pi_"$RPI_TYPE".tar.gz
-echo "Done Building Native GCC $GCC_VERSION Binaries..."
+tar cf - pi-gcc-"$GCC_VERSION"-$FOLDER_VERSION | pigz -9 -p 32 > gcc-"$GCC_VERSION"-pi_"$OS_TYPE".tar.gz
+echo "Done Building GCC $GCC_VERSION Binaries..."
 
 #clean path
-PATH=$(echo "$PATH" | sed -e 's;:\?$BUILDDIR/cross-pi-gcc-$GCC_VERSION-$FOLDER_VERSION/bin;;' -e 's;$BUILDDIR/cross-pi-gcc-$GCC_VERSION-$FOLDER_VERSION/bin:\?;;')
+PATH=$(echo "$PATH" | sed -e 's;:\?$BUILDDIR/pi-gcc-$GCC_VERSION-$FOLDER_VERSION/bin;;' -e 's;$BUILDDIR/pi-gcc-$GCC_VERSION-$FOLDER_VERSION/bin:\?;;')

--- a/build-scripts/CI/x86_64TB
+++ b/build-scripts/CI/x86_64TB
@@ -85,7 +85,7 @@ fi
 if ! [[ "$OS_TYPE" =~ ^("x86"|"x86_64")$ ]]; then exit 1 ; fi
 
 if [ "$OS_TYPE" = "x86_64" ]; then
-	ARCH=x86-64
+	ARCH=x86_64
 else
 	ARCH=i386
 fi
@@ -96,11 +96,11 @@ if echo ${GCC_VERSION%.*} "8.3" | awk '{exit ( $1 >= $2 )}'; then
 fi
 
 #pre-defined params
-TARGET=$ARCH-linux-gnu
+TARGET=$ARCH-debian-linux
 FOLDER_VERSION=$OS_TYPE
 GLIBC_VERSION=2.28
 BINUTILS_VERSION=2.31
-GDB_VERSION=9.1
+GDB_VERSION=9.2
 
 #validate env variables
 if [ "$BUILDDIR" = "" ]; then exit 1 ; fi
@@ -119,8 +119,8 @@ mkdir -p "$INSTALLDIR"
 cd "$DOWNLOADDIR" || exit
 #download binaries if not found
 if [ ! -d "linux" ]; then
-	wget -q https://github.com/$(wget -q https://github.com/raspberrypi/linux/releases/latest -O - | egrep '/.*/.*/.*.tar.gz' -o)
-	tar xf raspberrypi*.tar.gz
+	wget -q https://github.com/$(wget -q https://github.com/torvalds/linux/releases/latest -O - | egrep '/.*/.*/.*.tar.gz' -o)
+	tar xf v5.*.tar.gz
 	mv linux* linux
 	rm ./*.tar.*
 fi

--- a/build-scripts/CI/x86_64TB
+++ b/build-scripts/CI/x86_64TB
@@ -3,7 +3,7 @@
 
 # ===============================================
 # Raspberry Pi Toolchains(raspberry-pi-cross-compilers): This project 
-# provides latest automated GCC Cross Compiler & (ARM & ARM64) 
+# provides latest automated GCC Desktop Compiler & (ARM & ARM64) 
 # build-scripts and precompiled standalone toolchains for Raspberry Pi.
 
 
@@ -26,7 +26,7 @@
 
 
 
-# This script aauto downloads, compiles, and compresses Cross & GCC ARM64 Toolchain 
+# This script aauto downloads, compiles, and compresses Desktop & GCC ARM64 Toolchain 
 # binaries targeting any Raspberry Pi 64-bit (like Pi64) OSes.
 
 
@@ -86,10 +86,8 @@ if ! [[ "$OS_TYPE" =~ ^("x86"|"x86_64")$ ]]; then exit 1 ; fi
 
 if [ "$OS_TYPE" = "x86_64" ]; then
 	ARCH=x86-64
-	OPTS=-m64
 else
 	ARCH=i386
-	OPTS=-m32
 fi
 
 if echo ${GCC_VERSION%.*} "8.3" | awk '{exit ( $1 >= $2 )}'; then
@@ -98,22 +96,72 @@ if echo ${GCC_VERSION%.*} "8.3" | awk '{exit ( $1 >= $2 )}'; then
 fi
 
 #pre-defined params
-TARGET=x86_64-linux-gnu
+TARGET=$ARCH-linux-gnu
 FOLDER_VERSION=$OS_TYPE
+GLIBC_VERSION=2.28
+BINUTILS_VERSION=2.31
 GDB_VERSION=9.1
 
 #validate env variables
 if [ "$BUILDDIR" = "" ]; then exit 1 ; fi
 if [ "$LANGUAGES" = "" ]; then exit 1 ; fi
-if [ "$OPTS" = "" ]; then exit 1 ; fi
 
 echo "Downloading and Setting up build directories"
 #setup paths
 DOWNLOADDIR=$BUILDDIR/build_toolchains
-mkdir -p "$DOWNLOADDIR"
-cd "$DOWNLOADDIR" || exit
+INSTALLDIR=$BUILDDIR/pi-gcc-$GCC_VERSION-$FOLDER_VERSION
+SYSROOTDIR=$BUILDDIR/pi-gcc-$GCC_VERSION-$FOLDER_VERSION/$TARGET/libc
 
+#make dirs
+mkdir -p "$DOWNLOADDIR"
+mkdir -p "$INSTALLDIR"
+
+cd "$DOWNLOADDIR" || exit
 #download binaries if not found
+if [ ! -d "linux" ]; then
+	wget -q https://github.com/$(wget -q https://github.com/raspberrypi/linux/releases/latest -O - | egrep '/.*/.*/.*.tar.gz' -o)
+	tar xf raspberrypi*.tar.gz
+	mv linux* linux
+	rm ./*.tar.*
+fi
+if [ ! -d "gcc-$GCC_VERSION" ]; then
+	if [ ! -f "gcc-$GCC_VERSION.tar.gz" ]; then 
+		wget -q https://ftpmirror.gnu.org/gcc/gcc-$GCC_VERSION/gcc-$GCC_VERSION.tar.gz; 
+	fi
+	tar xf gcc-$GCC_VERSION.tar.gz
+	cd gcc-$GCC_VERSION || exit
+	mkdir -p build 
+	if [ "$GCC_VERSION" = "6.3.0" ]; then
+		sed -i contrib/download_prerequisites -e 's/ftp/http/';
+	else
+		sed -i contrib/download_prerequisites -e '/base_url=/s/ftp/http/';
+	fi
+	contrib/download_prerequisites
+	rm ./*.tar.*
+	if [ "$GCC_VERSION" = "6.3.0" ]; then sed -i "1474s/.*/      || xloc.file[0] == '\\\0' || xloc.file[0] == '\\\xff'/" ./gcc/ubsan.c; fi #apply patch
+	cd "$DOWNLOADDIR" || exit
+	rm ./*.tar.*
+fi
+if [ ! -d "binutils-$BINUTILS_VERSION" ]; then
+	if [ ! -f "binutils-$BINUTILS_VERSION.tar.bz2" ]; then 
+		wget -q https://ftp.gnu.org/gnu/binutils/binutils-$BINUTILS_VERSION.tar.bz2; 
+	fi
+	tar xf binutils-$BINUTILS_VERSION.tar.bz2
+	cd binutils-$BINUTILS_VERSION || exit
+	mkdir -p build 
+	cd "$DOWNLOADDIR" || exit
+	rm ./*.tar.*
+fi
+if [ ! -d "glibc-$GLIBC_VERSION" ]; then
+	if [ ! -f "glibc-$GLIBC_VERSION.tar.bz2" ]; then 
+		wget -q https://ftpmirror.gnu.org/glibc/glibc-$GLIBC_VERSION.tar.bz2; 
+	fi
+	tar xf  glibc-$GLIBC_VERSION.tar.bz2
+	cd glibc-$GLIBC_VERSION || exit
+	mkdir -p build 
+	cd "$DOWNLOADDIR" || exit
+	rm ./*.tar.*
+fi
 if [ ! -d "gdb-$GDB_VERSION" ]; then
 	if [ ! -f "gdb-$GDB_VERSION.tar.xz" ]; then 
 		wget -q https://ftp.gnu.org/gnu/gdb/gdb-$GDB_VERSION.tar.xz; 
@@ -124,47 +172,69 @@ if [ ! -d "gdb-$GDB_VERSION" ]; then
 	cd "$DOWNLOADDIR" || exit
 	rm ./*.tar.*
 fi
-if [ ! -d "gcc-$GCC_VERSION" ]; then
-	if [ ! -f "gcc-$GCC_VERSION.tar.gz" ]; then 
-		wget -q  https://ftpmirror.gnu.org/gcc/gcc-"$GCC_VERSION"/gcc-"$GCC_VERSION".tar.gz; 
-	fi
-	tar xf gcc-"$GCC_VERSION".tar.gz
-	cd gcc-"$GCC_VERSION" || exit
-	mkdir -p build 
-	sed -i contrib/download_prerequisites -e '/base_url=/s/ftp/http/'
-	contrib/download_prerequisites
-	rm ./*.tar.*
-	cd "$DOWNLOADDIR" || exit
-	rm ./*.tar.*
-fi
 
 echo "Setting up paths..."
+PATH=$BUILDDIR/pi-gcc-$GCC_VERSION-$FOLDER_VERSION/bin:$PATH
+unset LD_LIBRARY_PATH #patch
 
-echo "Building GCC $GCC_VERSION Binaries..."
-mkdir -p "$BUILDDIR"/pi-gcc-"$GCC_VERSION"-$FOLDER_VERSION
-cd "$DOWNLOADDIR"/gcc-"$GCC_VERSION"/build || exit
-if [ -n "$(ls -A "$DOWNLOADDIR"/gcc-"$GCC_VERSION"/build)" ]; then rm -rf "$DOWNLOADDIR"/gcc-"$GCC_VERSION"/build/*; fi
-../configure --prefix= --build="$MACHTYPE" --host=$TARGET --target=$TARGET --enable-languages=$LANGUAGES --with-arch=$ARCH  $OPTS  --disable-multilib --program-suffix=-"$GCC_VERSION"
-make -s -j$(nproc)
-make -s install-strip DESTDIR="$BUILDDIR"/pi-gcc-"$GCC_VERSION"-$FOLDER_VERSION
-if [ -n "$(ls -A "$DOWNLOADDIR"/gcc-"$GCC_VERSION"/build)" ]; then rm -rf "$DOWNLOADDIR"/gcc-"$GCC_VERSION"/build/*; fi
-cd "$DOWNLOADDIR"/gcc-"$GCC_VERSION" || exit
-cat gcc/limitx.h gcc/glimits.h gcc/limity.h > "$BUILDDIR"/pi-gcc-"$GCC_VERSION"-$FOLDER_VERSION/lib/gcc/$TARGET/"$GCC_VERSION"/include-fixed/limits.h
 
-echo "Building GDB Binaries..."
+echo "Building Kernel Headers..."
+cd "$DOWNLOADDIR"/linux || exit
+make -s ARCH=$ARCH INSTALL_HDR_PATH="$SYSROOTDIR"/usr headers_install
+mkdir -p "$SYSROOTDIR"/usr/lib
+
+
+echo "Building binutils..."
+if [ -n "$(ls -A "$DOWNLOADDIR"/binutils-$BINUTILS_VERSION/build)" ]; then rm -rf "$DOWNLOADDIR"/binutils-$BINUTILS_VERSION/build/*; fi
+cd "$DOWNLOADDIR"/binutils-$BINUTILS_VERSION/build || exit
+../configure --target=$TARGET --prefix= --with-arch=$ARCH --with-sysroot=/$TARGET/libc --with-build-sysroot="$SYSROOTDIR" --disable-multilib
+make -s -j$(getconf _NPROCESSORS_ONLN)
+make -s install DESTDIR="$INSTALLDIR"
+if [ -n "$(ls -A "$DOWNLOADDIR"/binutils-$BINUTILS_VERSION/build)" ]; then rm -rf "$DOWNLOADDIR"/binutils-$BINUTILS_VERSION/build/*; fi
+
+
+echo "Building Desktop GCC $GCC_VERSION Binaries..."
+if [ -n "$(ls -A "$DOWNLOADDIR"/gcc-$GCC_VERSION/build)" ]; then rm -rf "$DOWNLOADDIR"/gcc-$GCC_VERSION/build/*; fi
+cd "$DOWNLOADDIR"/gcc-$GCC_VERSION/build || exit
+../configure --prefix= --target=$TARGET --enable-languages=$LANGUAGES --with-sysroot=/$TARGET/libc --with-build-sysroot="$SYSROOTDIR" --with-arch=$ARCH  --disable-multilib
+make -s -j$(getconf _NPROCESSORS_ONLN) all-gcc
+make -s install-gcc DESTDIR="$INSTALLDIR"
+if [ -n "$(ls -A "$DOWNLOADDIR"/glibc-$GLIBC_VERSION/build)" ]; then rm -rf "$DOWNLOADDIR"/glibc-$GLIBC_VERSION/build/*; fi
+cd "$DOWNLOADDIR"/glibc-$GLIBC_VERSION/build || exit
+../configure --prefix=/usr --build="$MACHTYPE" --host=$TARGET --target=$TARGET --with-arch=$ARCH --with-sysroot=/$TARGET/libc --with-build-sysroot="$SYSROOTDIR" --with-headers="$SYSROOTDIR"/usr/include --with-lib="$SYSROOTDIR"/usr/lib --disable-multilib libc_cv_forced_unwind=yes
+make -s install-bootstrap-headers=yes install-headers DESTDIR="$SYSROOTDIR"
+make -s -j$(getconf _NPROCESSORS_ONLN) csu/subdir_lib
+install csu/crt1.o csu/crti.o csu/crtn.o "$SYSROOTDIR"/usr/lib
+$TARGET-gcc -nostdlib -nostartfiles -shared -x c /dev/null -o "$SYSROOTDIR"/usr/lib/libc.so
+touch "$SYSROOTDIR"/usr/include/gnu/stubs.h "$SYSROOTDIR"/usr/include/bits/stdio_lim.h
+cd "$DOWNLOADDIR"/gcc-$GCC_VERSION/build || exit
+make -s -j$(getconf _NPROCESSORS_ONLN) all-target-libgcc
+make -s install-target-libgcc DESTDIR="$INSTALLDIR"
+cd "$DOWNLOADDIR"/glibc-$GLIBC_VERSION/build || exit
+make -s -j$(getconf _NPROCESSORS_ONLN)
+make -s install DESTDIR="$SYSROOTDIR"
+cd "$DOWNLOADDIR"/gcc-$GCC_VERSION/build || exit
+if [ -n "$(ls -A "$DOWNLOADDIR"/glibc-$GLIBC_VERSION/build)" ]; then rm -rf "$DOWNLOADDIR"/glibc-$GLIBC_VERSION/build/*; fi
+make -s -j$(getconf _NPROCESSORS_ONLN)
+make -s install DESTDIR="$INSTALLDIR"
+if [ -n "$(ls -A "$DOWNLOADDIR"/gcc-$GCC_VERSION/build)" ]; then rm -rf "$DOWNLOADDIR"/gcc-$GCC_VERSION/build/*; fi
+cd  "$DOWNLOADDIR"/gcc-"$GCC_VERSION" || exit
+cat gcc/limitx.h gcc/glimits.h gcc/limity.h > $(dirname $($TARGET-gcc -print-libgcc-file-name))/include-fixed/limits.h
+
+echo "Building Desktop GDB Binaries..."
 cd "$DOWNLOADDIR"/gdb-$GDB_VERSION/build || exit
 if [ -n "$(ls -A "$DOWNLOADDIR"/gdb-$GDB_VERSION/build)" ]; then rm -rf "$DOWNLOADDIR"/gdb-$GDB_VERSION/build/*; fi
-../configure --prefix= --build="$MACHTYPE" --host=$TARGET --target=$TARGET --with-arch=$ARCH  $OPTS --program-suffix=-"$GCC_VERSION"
+../configure --prefix= --target=$TARGET --with-arch=$ARCH  --with-float=hard -with-sysroot=/$TARGET/libc --with-build-sysroot="$SYSROOTDIR"
 make -s -j$(nproc)
-make -s install DESTDIR="$BUILDDIR"/pi-gcc-"$GCC_VERSION"-$FOLDER_VERSION
+make -s install DESTDIR="$INSTALLDIR"
 if [ -n "$(ls -A "$DOWNLOADDIR"/gdb-$GDB_VERSION/build)" ]; then rm -rf "$DOWNLOADDIR"/gdb-$GDB_VERSION/build/*; fi
-echo "Done Building GDB Binaries..."
+echo "Done Building Desktop GDB Binaries..."
 
 mv "$BUILDDIR"/pi-gcc-"$GCC_VERSION"-$FOLDER_VERSION "$HOME"
 cd "$HOME" || exit
 #compress with maximum possible compression level.
-tar cf - pi-gcc-"$GCC_VERSION"-$FOLDER_VERSION | pigz -9 -p 32 > gcc-"$GCC_VERSION"-pi_"$OS_TYPE".tar.gz
-echo "Done Building GCC $GCC_VERSION Binaries..."
+tar cf - pi-gcc-"$GCC_VERSION"-$FOLDER_VERSION | pigz -9 -p 32 > gcc-"$GCC_VERSION"-pi_"$FOLDER_VERSION".tar.gz
+echo "Done Building Desktop GCC $GCC_VERSION BASE Binaries..."
 
 #clean path
 PATH=$(echo "$PATH" | sed -e 's;:\?$BUILDDIR/pi-gcc-$GCC_VERSION-$FOLDER_VERSION/bin;;' -e 's;$BUILDDIR/pi-gcc-$GCC_VERSION-$FOLDER_VERSION/bin:\?;;')

--- a/build-scripts/README.md
+++ b/build-scripts/README.md
@@ -110,7 +110,7 @@ You can run these bash scripts to manually compile any GCC toolchains version th
   
         ```shellsession
         Usage: ./RTBuilder_32b -g [GCC version] -r [Target Pi type] -o [Target Pi OS type]
-            -g GCC version you want to compile?: (7.1.0|7.2.0|7.3.0|7.4.0|7.5.0|8.1.0|8.2.0|8.3.0|8.4.0|9.1.0|9.2.0|9.3.0|10.1.0)
+            -g GCC version you want to compile?: (7.1.0|7.2.0|7.3.0|7.4.0|7.5.0|8.1.0|8.2.0|8.3.0|8.4.0|9.1.0|9.2.0|9.3.0|10.1.0|10.2.0)
             -r What's yours Raspberry Pi type?: (0-1|2-3|3+)
             -o What's yours Raspberry Pi OS type?: (stretch|buster)
         ```
@@ -136,7 +136,7 @@ You can run these bash scripts to manually compile any GCC toolchains version th
       
         ```shellsession
         Usage: ./RTBuilder_64b -g [GCC version] -t [OS Type]
-            -g GCC version you want to compile?: (7.1.0|7.2.0|7.3.0|7.4.0|7.5.0|8.1.0|8.2.0|8.3.0|8.4.0|9.1.0|9.2.0|9.3.0|10.1.0)
+            -g GCC version you want to compile?: (7.1.0|7.2.0|7.3.0|7.4.0|7.5.0|8.1.0|8.2.0|8.3.0|8.4.0|9.1.0|9.2.0|9.3.0|10.1.0|10.2.0)
             -t What's yours Raspberry Pi OS type?: (1|2) [default:1]
 
         ``` 
@@ -195,6 +195,7 @@ These scripts only support newer GCC versions, those are as follows:
 | 9.2.0 | supported | supported | supported |
 | 9.3.0 | supported | supported | supported |
 | 10.1.0 | supported | supported | supported |
+| 10.2.0 | supported | supported | supported |
 
 &nbsp;
 

--- a/build-scripts/RTBuilder_32b
+++ b/build-scripts/RTBuilder_32b
@@ -42,7 +42,7 @@ helpfunction()
    echo ""
    echo ""
    echo "Usage: $0 -g [GCC version] -r [Target Pi type] -o [Target Pi OS type]"
-   echo -e "\t-g GCC version you want to compile?: (7.1.0|7.2.0|7.3.0|7.4.0|7.5.0|8.1.0|8.2.0|8.3.0|9.1.0|9.2.0|9.3.0|10.1.0)"
+   echo -e "\t-g GCC version you want to compile?: (7.1.0|7.2.0|7.3.0|7.4.0|7.5.0|8.1.0|8.2.0|8.3.0|9.1.0|9.2.0|9.3.0|10.1.0|10.2.0)"
    echo -e "\t-r What's yours Target Raspberry Pi type?: (0-1|2-3|3+)"
    echo -e "\t-o What's yours Target Raspberry Pi OS type?: (stretch|buster)"
    echo ""
@@ -132,10 +132,10 @@ fi
 
 #pre-defined params
 TARGET=arm-linux-gnueabihf
-GDB_VERSION=9.1
+GDB_VERSION=9.2
 
 #validate env variables
-if ! [[ "$GCC_VERSION" =~ ^(7.1.0|7.2.0|7.3.0|7.4.0|7.5.0|8.1.0|8.2.0|8.3.0|9.1.0|9.2.0|9.3.0|10.1.0)$ ]]; then exit 1 ; fi
+if ! [[ "$GCC_VERSION" =~ ^(7.1.0|7.2.0|7.3.0|7.4.0|7.5.0|8.1.0|8.2.0|8.3.0|9.1.0|9.2.0|9.3.0|10.1.0|10.2.0)$ ]]; then exit 1 ; fi
 if ! [[ "$GCCBASE_VERSION" =~ ^(6.3.0|8.3.0)$ ]]; then exit 1 ; fi
 if ! [[ "$GLIBC_VERSION" =~ ^(2.24|2.28)$ ]]; then exit 1 ; fi
 if ! [[ "$BINUTILS_VERSION" =~ ^(2.28|2.31)$ ]]; then exit 1 ; fi

--- a/build-scripts/RTBuilder_64b
+++ b/build-scripts/RTBuilder_64b
@@ -41,7 +41,7 @@ helpfunction()
    echo ""
    echo ""
    echo "Usage: $0 -g [GCC version] -t [Target OS type]"
-   echo -e "\t-g GCC version you want to compile?: (7.1.0|7.2.0|7.3.0|7.4.0|7.5.0|8.1.0|8.2.0|8.3.0|9.1.0|9.2.0|9.3.0|10.1.0)"
+   echo -e "\t-g GCC version you want to compile?: (7.1.0|7.2.0|7.3.0|7.4.0|7.5.0|8.1.0|8.2.0|8.3.0|9.1.0|9.2.0|9.3.0|10.1.0|10.2.0)"
    echo -e "\t-t What's yours Target OS type?: (1|2) [default:1]"
    echo ""
    echo ""
@@ -105,11 +105,11 @@ FOLDER_VERSION=64
 KERNEL=kernel7
 ARCH=armv8-a+fp+simd
 TARGET=aarch64-linux-gnu
-GDB_VERSION=9.1
+GDB_VERSION=9.2
 
 
 #validate env variables
-if ! [[ "$GCC_VERSION" =~ ^(7.1.0|7.2.0|7.3.0|7.4.0|7.5.0|8.1.0|8.2.0|8.3.0|9.1.0|9.2.0|9.3.0|10.1.0)$ ]]; then exit 1 ; fi
+if ! [[ "$GCC_VERSION" =~ ^(7.1.0|7.2.0|7.3.0|7.4.0|7.5.0|8.1.0|8.2.0|8.3.0|9.1.0|9.2.0|9.3.0|10.1.0|10.2.0)$ ]]; then exit 1 ; fi
 if ! [[ "$GCCBASE_VERSION" =~ ^(6.3.0|8.3.0)$ ]]; then exit 1 ; fi
 if ! [[ "$GLIBC_VERSION" =~ ^(2.24|2.28)$ ]]; then exit 1 ; fi
 if ! [[ "$BINUTILS_VERSION" =~ ^(2.28|2.31)$ ]]; then exit 1 ; fi

--- a/docs/base-gcc.md
+++ b/docs/base-gcc.md
@@ -71,13 +71,13 @@ This project now utilizes powerful [**Github Actions**][git-action] CI(Continuou
 
 | Toolchains | Host OS | Target OS | Current Status | Precompiled GCC versions available |
 | :---------- | :--------: | :-------: | :--------: | :------------------------: |
-| **Raspberry Pi GCC Cross-Compiler Toolchains(Stretch)** | any x64/x86 Linux machine | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 6.3.0,  9.2.0, 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC Cross-Compiler Toolchains(Buster)** | any x64/x86 Linux machine | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 8.3.0, 9.2.0, 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC Native-Compiler Toolchains(Stretch)** | Raspbian Stretch OS (Debian Version 9) only | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC Native-Compiler Toolchains(Buster)** | Raspbian Buster OS (Debian Version 10) only | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC 64-Bit Cross-Compiler Toolchains** | any x64/x86 Linux machine | any x64 Raspberry Pi OS(like Pi64) | Stable/Production | 6.3.0, 8.3.0, 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC 64-Bit Native-Compiler Toolchains** | any x64 Raspberry Pi OS(like Pi64) | any x64 Raspbian OS(like Pi64) | Stable/Production | 8.3.0, 9.3.0, 10.1.0 |
-| **Exclusive/Experimental Toolchains** |  None | None | Beta/Experimental | None | 
+| **Raspberry Pi GCC Cross-Compiler Toolchains(Stretch)** | any x64/x86 Linux machine | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 6.3.0,  9.3.0, 10.2.0 |
+| **Raspberry Pi GCC Cross-Compiler Toolchains(Buster)** | any x64/x86 Linux machine | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 8.3.0, 9.3.0, 10.2.0 |
+| **Raspberry Pi GCC Native-Compiler Toolchains(Stretch)** | Raspbian Stretch OS (Debian Version 9) only | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 9.3.0, 10.2.0 |
+| **Raspberry Pi GCC Native-Compiler Toolchains(Buster)** | Raspbian Buster OS (Debian Version 10) only | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 9.3.0, 10.2.0 |
+| **Raspberry Pi GCC 64-Bit Cross-Compiler Toolchains** | any x64/x86 Linux machine | any x64 Raspberry Pi OS(like Pi64) | Stable/Production | 6.3.0, 8.3.0, 9.3.0, 10.2.0 |
+| **Raspberry Pi GCC 64-Bit Native-Compiler Toolchains** | any x64 Raspberry Pi OS(like Pi64) | any x64 Raspbian OS(like Pi64) | Stable/Production | 8.3.0, 9.3.0, 10.2.0 |
+| **Exclusive/Experimental Toolchains** |  x86/x86_64 Pi Desktop | x86/x86_64 Pi Desktop | Beta/Experimental | 10.2.0 | 
 
 
 **Tip:** _To get the location of each Binary of this project on SourceForge, you can also check out [this Reference Tree](https://github.com/abhiTronix/raspberry-pi-cross-compilers/wiki/Toolchain-Binaries-Reference-Tree#toolchain-binaries-reference-tree)._
@@ -218,9 +218,9 @@ Thank you,
 [pigz]:https://zlib.net/pigz/
 
 [cc-stretch-630]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Stretch/GCC%206.3.0/
-[cc-stretch-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Stretch/GCC%209.2.0/
+
 [cc-buster-830]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Buster/GCC%208.3.0/
-[cc-buster-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Buster/GCC%209.2.0/
+
 [nc-stretch-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Native-Compiler%20Toolchains/Stretch/
 [nc-buster-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Native-Compiler%20Toolchains/Buster/
 [cc-64-630]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Bonus%20Raspberry%20Pi%20GCC%2064-Bit%20Toolchains/Raspberry%20Pi%20GCC%2064-Bit%20Cross-Compiler%20Toolchains/GCC%206.3.0/

--- a/docs/cross-gcc-buster.md
+++ b/docs/cross-gcc-buster.md
@@ -69,13 +69,13 @@ This project now utilizes powerful [**Github Actions**][git-action] CI(Continuou
 
 | Toolchains | Host OS | Target OS | Current Status | Precompiled GCC versions available |
 | :---------- | :--------: | :-------: | :--------: | :------------------------: |
-| **Raspberry Pi GCC Cross-Compiler Toolchains(Stretch)** | any x64/x86 Linux machine | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 6.3.0,  9.2.0, 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC Cross-Compiler Toolchains(Buster)** | any x64/x86 Linux machine | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 8.3.0, 9.2.0, 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC Native-Compiler Toolchains(Stretch)** | Raspbian Stretch OS (Debian Version 9) only | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC Native-Compiler Toolchains(Buster)** | Raspbian Buster OS (Debian Version 10) only | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC 64-Bit Cross-Compiler Toolchains** | any x64/x86 Linux machine | any x64 Raspberry Pi OS(like Pi64) | Stable/Production | 6.3.0, 8.3.0, 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC 64-Bit Native-Compiler Toolchains** | any x64 Raspberry Pi OS(like Pi64) | any x64 Raspbian OS(like Pi64) | Stable/Production | 8.3.0, 9.3.0, 10.1.0 |
-| **Exclusive/Experimental Toolchains** |  None | None | Beta/Experimental | None | 
+| **Raspberry Pi GCC Cross-Compiler Toolchains(Stretch)** | any x64/x86 Linux machine | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 6.3.0,  9.3.0, 10.2.0 |
+| **Raspberry Pi GCC Cross-Compiler Toolchains(Buster)** | any x64/x86 Linux machine | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 8.3.0, 9.3.0, 10.2.0 |
+| **Raspberry Pi GCC Native-Compiler Toolchains(Stretch)** | Raspbian Stretch OS (Debian Version 9) only | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 9.3.0, 10.2.0 |
+| **Raspberry Pi GCC Native-Compiler Toolchains(Buster)** | Raspbian Buster OS (Debian Version 10) only | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 9.3.0, 10.2.0 |
+| **Raspberry Pi GCC 64-Bit Cross-Compiler Toolchains** | any x64/x86 Linux machine | any x64 Raspberry Pi OS(like Pi64) | Stable/Production | 6.3.0, 8.3.0, 9.3.0, 10.2.0 |
+| **Raspberry Pi GCC 64-Bit Native-Compiler Toolchains** | any x64 Raspberry Pi OS(like Pi64) | any x64 Raspbian OS(like Pi64) | Stable/Production | 8.3.0, 9.3.0, 10.2.0 |
+| **Exclusive/Experimental Toolchains** |  x86/x86_64 Pi Desktop | x86/x86_64 Pi Desktop | Beta/Experimental | 10.2.0 | 
    
 
 **Tip:** _To get the location of each Binary of this project on SourceForge, you can also check out [this Reference Tree](https://github.com/abhiTronix/raspberry-pi-cross-compilers/wiki/Toolchain-Binaries-Reference-Tree#toolchain-binaries-reference-tree)._
@@ -216,9 +216,9 @@ Thank you,
 [pigz]:https://zlib.net/pigz/
 
 [cc-stretch-630]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Stretch/GCC%206.3.0/
-[cc-stretch-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Stretch/GCC%209.2.0/
+
 [cc-buster-830]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Buster/GCC%208.3.0/
-[cc-buster-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Buster/GCC%209.2.0/
+
 [nc-stretch-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Native-Compiler%20Toolchains/Stretch/
 [nc-buster-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Native-Compiler%20Toolchains/Buster/
 [cc-64-630]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Bonus%20Raspberry%20Pi%20GCC%2064-Bit%20Toolchains/Raspberry%20Pi%20GCC%2064-Bit%20Cross-Compiler%20Toolchains/GCC%206.3.0/

--- a/docs/cross-gcc-stretch.md
+++ b/docs/cross-gcc-stretch.md
@@ -71,13 +71,13 @@ This project now utilizes powerful [**Github Actions**][git-action] CI(Continuou
 
 | Toolchains | Host OS | Target OS | Current Status | Precompiled GCC versions available |
 | :---------- | :--------: | :-------: | :--------: | :------------------------: |
-| **Raspberry Pi GCC Cross-Compiler Toolchains(Stretch)** | any x64/x86 Linux machine | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 6.3.0,  9.2.0, 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC Cross-Compiler Toolchains(Buster)** | any x64/x86 Linux machine | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 8.3.0, 9.2.0, 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC Native-Compiler Toolchains(Stretch)** | Raspbian Stretch OS (Debian Version 9) only | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC Native-Compiler Toolchains(Buster)** | Raspbian Buster OS (Debian Version 10) only | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC 64-Bit Cross-Compiler Toolchains** | any x64/x86 Linux machine | any x64 Raspberry Pi OS(like Pi64) | Stable/Production | 6.3.0, 8.3.0, 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC 64-Bit Native-Compiler Toolchains** | any x64 Raspberry Pi OS(like Pi64) | any x64 Raspbian OS(like Pi64) | Stable/Production | 8.3.0, 9.3.0, 10.1.0 |
-| **Exclusive/Experimental Toolchains** |  None | None | Beta/Experimental | None | 
+| **Raspberry Pi GCC Cross-Compiler Toolchains(Stretch)** | any x64/x86 Linux machine | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 6.3.0,  9.3.0, 10.2.0 |
+| **Raspberry Pi GCC Cross-Compiler Toolchains(Buster)** | any x64/x86 Linux machine | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 8.3.0, 9.3.0, 10.2.0 |
+| **Raspberry Pi GCC Native-Compiler Toolchains(Stretch)** | Raspbian Stretch OS (Debian Version 9) only | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 9.3.0, 10.2.0 |
+| **Raspberry Pi GCC Native-Compiler Toolchains(Buster)** | Raspbian Buster OS (Debian Version 10) only | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 9.3.0, 10.2.0 |
+| **Raspberry Pi GCC 64-Bit Cross-Compiler Toolchains** | any x64/x86 Linux machine | any x64 Raspberry Pi OS(like Pi64) | Stable/Production | 6.3.0, 8.3.0, 9.3.0, 10.2.0 |
+| **Raspberry Pi GCC 64-Bit Native-Compiler Toolchains** | any x64 Raspberry Pi OS(like Pi64) | any x64 Raspbian OS(like Pi64) | Stable/Production | 8.3.0, 9.3.0, 10.2.0 |
+| **Exclusive/Experimental Toolchains** |  x86/x86_64 Pi Desktop | x86/x86_64 Pi Desktop | Beta/Experimental | 10.2.0 | 
 
 
 **Tip:** _To get the location of each Binary of this project on SourceForge, you can also check out [this Reference Tree](https://github.com/abhiTronix/raspberry-pi-cross-compilers/wiki/Toolchain-Binaries-Reference-Tree#toolchain-binaries-reference-tree)._
@@ -218,9 +218,9 @@ Thank you,
 [pigz]:https://zlib.net/pigz/
 
 [cc-stretch-630]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Stretch/GCC%206.3.0/
-[cc-stretch-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Stretch/GCC%209.2.0/
+
 [cc-buster-830]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Buster/GCC%208.3.0/
-[cc-buster-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Buster/GCC%209.2.0/
+
 [nc-stretch-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Native-Compiler%20Toolchains/Stretch/
 [nc-buster-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Native-Compiler%20Toolchains/Buster/
 [cc-64-630]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Bonus%20Raspberry%20Pi%20GCC%2064-Bit%20Toolchains/Raspberry%20Pi%20GCC%2064-Bit%20Cross-Compiler%20Toolchains/GCC%206.3.0/

--- a/docs/cross-gcc.md
+++ b/docs/cross-gcc.md
@@ -70,13 +70,13 @@ This project now utilizes powerful [**Github Actions**][git-action] CI(Continuou
 
 | Toolchains | Host OS | Target OS | Current Status | Precompiled GCC versions available |
 | :---------- | :--------: | :-------: | :--------: | :------------------------: |
-| **Raspberry Pi GCC Cross-Compiler Toolchains(Stretch)** | any x64/x86 Linux machine | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 6.3.0,  9.2.0, 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC Cross-Compiler Toolchains(Buster)** | any x64/x86 Linux machine | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 8.3.0, 9.2.0, 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC Native-Compiler Toolchains(Stretch)** | Raspbian Stretch OS (Debian Version 9) only | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC Native-Compiler Toolchains(Buster)** | Raspbian Buster OS (Debian Version 10) only | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC 64-Bit Cross-Compiler Toolchains** | any x64/x86 Linux machine | any x64 Raspberry Pi OS(like Pi64) | Stable/Production | 6.3.0, 8.3.0, 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC 64-Bit Native-Compiler Toolchains** | any x64 Raspberry Pi OS(like Pi64) | any x64 Raspbian OS(like Pi64) | Stable/Production | 8.3.0, 9.3.0, 10.1.0 |
-| **Exclusive/Experimental Toolchains** |  None | None | Beta/Experimental | None | 
+| **Raspberry Pi GCC Cross-Compiler Toolchains(Stretch)** | any x64/x86 Linux machine | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 6.3.0,  9.3.0, 10.2.0 |
+| **Raspberry Pi GCC Cross-Compiler Toolchains(Buster)** | any x64/x86 Linux machine | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 8.3.0, 9.3.0, 10.2.0 |
+| **Raspberry Pi GCC Native-Compiler Toolchains(Stretch)** | Raspbian Stretch OS (Debian Version 9) only | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 9.3.0, 10.2.0 |
+| **Raspberry Pi GCC Native-Compiler Toolchains(Buster)** | Raspbian Buster OS (Debian Version 10) only | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 9.3.0, 10.2.0 |
+| **Raspberry Pi GCC 64-Bit Cross-Compiler Toolchains** | any x64/x86 Linux machine | any x64 Raspberry Pi OS(like Pi64) | Stable/Production | 6.3.0, 8.3.0, 9.3.0, 10.2.0 |
+| **Raspberry Pi GCC 64-Bit Native-Compiler Toolchains** | any x64 Raspberry Pi OS(like Pi64) | any x64 Raspbian OS(like Pi64) | Stable/Production | 8.3.0, 9.3.0, 10.2.0 |
+| **Exclusive/Experimental Toolchains** |  x86/x86_64 Pi Desktop | x86/x86_64 Pi Desktop | Beta/Experimental | 10.2.0 | 
 
 
 **Tip:** _To get the location of each Binary of this project on SourceForge, you can also check out [this Reference Tree](https://github.com/abhiTronix/raspberry-pi-cross-compilers/wiki/Toolchain-Binaries-Reference-Tree#toolchain-binaries-reference-tree)._
@@ -217,9 +217,9 @@ Thank you,
 [pigz]:https://zlib.net/pigz/
 
 [cc-stretch-630]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Stretch/GCC%206.3.0/
-[cc-stretch-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Stretch/GCC%209.2.0/
+
 [cc-buster-830]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Buster/GCC%208.3.0/
-[cc-buster-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Buster/GCC%209.2.0/
+
 [nc-stretch-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Native-Compiler%20Toolchains/Stretch/
 [nc-buster-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Native-Compiler%20Toolchains/Buster/
 [cc-64-630]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Bonus%20Raspberry%20Pi%20GCC%2064-Bit%20Toolchains/Raspberry%20Pi%20GCC%2064-Bit%20Cross-Compiler%20Toolchains/GCC%206.3.0/

--- a/docs/cross-gcc64.md
+++ b/docs/cross-gcc64.md
@@ -69,13 +69,13 @@ This project now utilizes powerful [**Github Actions**][git-action] CI(Continuou
 
 | Toolchains | Host OS | Target OS | Current Status | Precompiled GCC versions available |
 | :---------- | :--------: | :-------: | :--------: | :------------------------: |
-| **Raspberry Pi GCC Cross-Compiler Toolchains(Stretch)** | any x64/x86 Linux machine | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 6.3.0,  9.2.0, 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC Cross-Compiler Toolchains(Buster)** | any x64/x86 Linux machine | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 8.3.0, 9.2.0, 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC Native-Compiler Toolchains(Stretch)** | Raspbian Stretch OS (Debian Version 9) only | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC Native-Compiler Toolchains(Buster)** | Raspbian Buster OS (Debian Version 10) only | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC 64-Bit Cross-Compiler Toolchains** | any x64/x86 Linux machine | any x64 Raspberry Pi OS(like Pi64) | Stable/Production | 6.3.0, 8.3.0, 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC 64-Bit Native-Compiler Toolchains** | any x64 Raspberry Pi OS(like Pi64) | any x64 Raspbian OS(like Pi64) | Stable/Production | 8.3.0, 9.3.0, 10.1.0 |
-| **Exclusive/Experimental Toolchains** |  None | None | Beta/Experimental | None |  
+| **Raspberry Pi GCC Cross-Compiler Toolchains(Stretch)** | any x64/x86 Linux machine | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 6.3.0,  9.3.0, 10.2.0 |
+| **Raspberry Pi GCC Cross-Compiler Toolchains(Buster)** | any x64/x86 Linux machine | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 8.3.0, 9.3.0, 10.2.0 |
+| **Raspberry Pi GCC Native-Compiler Toolchains(Stretch)** | Raspbian Stretch OS (Debian Version 9) only | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 9.3.0, 10.2.0 |
+| **Raspberry Pi GCC Native-Compiler Toolchains(Buster)** | Raspbian Buster OS (Debian Version 10) only | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 9.3.0, 10.2.0 |
+| **Raspberry Pi GCC 64-Bit Cross-Compiler Toolchains** | any x64/x86 Linux machine | any x64 Raspberry Pi OS(like Pi64) | Stable/Production | 6.3.0, 8.3.0, 9.3.0, 10.2.0 |
+| **Raspberry Pi GCC 64-Bit Native-Compiler Toolchains** | any x64 Raspberry Pi OS(like Pi64) | any x64 Raspbian OS(like Pi64) | Stable/Production | 8.3.0, 9.3.0, 10.2.0 |
+| **Exclusive/Experimental Toolchains** |  x86/x86_64 Pi Desktop | x86/x86_64 Pi Desktop | Beta/Experimental | 10.2.0 |  
 
 
 **Tip:** _To get the location of each Binary of this project on SourceForge, you can also check out [this Reference Tree](https://github.com/abhiTronix/raspberry-pi-cross-compilers/wiki/Toolchain-Binaries-Reference-Tree#toolchain-binaries-reference-tree)._
@@ -216,9 +216,9 @@ Thank you,
 [pigz]:https://zlib.net/pigz/
 
 [cc-stretch-630]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Stretch/GCC%206.3.0/
-[cc-stretch-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Stretch/GCC%209.2.0/
+
 [cc-buster-830]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Buster/GCC%208.3.0/
-[cc-buster-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Buster/GCC%209.2.0/
+
 [nc-stretch-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Native-Compiler%20Toolchains/Stretch/
 [nc-buster-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Native-Compiler%20Toolchains/Buster/
 [cc-64-630]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Bonus%20Raspberry%20Pi%20GCC%2064-Bit%20Toolchains/Raspberry%20Pi%20GCC%2064-Bit%20Cross-Compiler%20Toolchains/GCC%206.3.0/

--- a/docs/desktop-gcc-x86.md
+++ b/docs/desktop-gcc-x86.md
@@ -69,13 +69,13 @@ This project now utilizes powerful [**Github Actions**][git-action] CI(Continuou
 
 | Toolchains | Host OS | Target OS | Current Status | Precompiled GCC versions available |
 | :---------- | :--------: | :-------: | :--------: | :------------------------: |
-| **Raspberry Pi GCC Cross-Compiler Toolchains(Stretch)** | any x64/x86 Linux machine | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 6.3.0,  9.2.0, 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC Cross-Compiler Toolchains(Buster)** | any x64/x86 Linux machine | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 8.3.0, 9.2.0, 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC Native-Compiler Toolchains(Stretch)** | Raspbian Stretch OS (Debian Version 9) only | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC Native-Compiler Toolchains(Buster)** | Raspbian Buster OS (Debian Version 10) only | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC 64-Bit Cross-Compiler Toolchains** | any x64/x86 Linux machine | any x64 Raspberry Pi OS(like Pi64) | Stable/Production | 6.3.0, 8.3.0, 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC 64-Bit Native-Compiler Toolchains** | any x64 Raspberry Pi OS(like Pi64) | any x64 Raspbian OS(like Pi64) | Stable/Production | 8.3.0, 9.3.0, 10.1.0 |
-| **Exclusive/Experimental Toolchains** |  None | None | Beta/Experimental | None |  
+| **Raspberry Pi GCC Cross-Compiler Toolchains(Stretch)** | any x64/x86 Linux machine | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 6.3.0,  9.3.0, 10.2.0 |
+| **Raspberry Pi GCC Cross-Compiler Toolchains(Buster)** | any x64/x86 Linux machine | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 8.3.0, 9.3.0, 10.2.0 |
+| **Raspberry Pi GCC Native-Compiler Toolchains(Stretch)** | Raspbian Stretch OS (Debian Version 9) only | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 9.3.0, 10.2.0 |
+| **Raspberry Pi GCC Native-Compiler Toolchains(Buster)** | Raspbian Buster OS (Debian Version 10) only | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 9.3.0, 10.2.0 |
+| **Raspberry Pi GCC 64-Bit Cross-Compiler Toolchains** | any x64/x86 Linux machine | any x64 Raspberry Pi OS(like Pi64) | Stable/Production | 6.3.0, 8.3.0, 9.3.0, 10.2.0 |
+| **Raspberry Pi GCC 64-Bit Native-Compiler Toolchains** | any x64 Raspberry Pi OS(like Pi64) | any x64 Raspbian OS(like Pi64) | Stable/Production | 8.3.0, 9.3.0, 10.2.0 |
+| **Exclusive/Experimental Toolchains** |  x86/x86_64 Pi Desktop | x86/x86_64 Pi Desktop | Beta/Experimental | 10.2.0 |  
  
 
 
@@ -216,9 +216,9 @@ Thank you,
 [pigz]:https://zlib.net/pigz/
 
 [cc-stretch-630]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Stretch/GCC%206.3.0/
-[cc-stretch-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Stretch/GCC%209.2.0/
+
 [cc-buster-830]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Buster/GCC%208.3.0/
-[cc-buster-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Buster/GCC%209.2.0/
+
 [nc-stretch-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Native-Compiler%20Toolchains/Stretch/
 [nc-buster-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Native-Compiler%20Toolchains/Buster/
 [cc-64-630]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Bonus%20Raspberry%20Pi%20GCC%2064-Bit%20Toolchains/Raspberry%20Pi%20GCC%2064-Bit%20Cross-Compiler%20Toolchains/GCC%206.3.0/

--- a/docs/desktop-gcc-x86.md
+++ b/docs/desktop-gcc-x86.md
@@ -1,0 +1,228 @@
+<!--
+===============================================
+Raspberry Pi Toolchains(raspberry-pi-cross-compilers): This project 
+provides latest automated GCC Cross Compiler & Native (ARM & ARM64) 
+build-scripts and precompiled standalone toolchains for Raspberry Pi.
+
+
+Copyright (C) 2020 Abhishek Thakur(@abhiTronix) <abhi.una12@gmail.com>
+
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+===============================================
+-->
+
+<br>
+
+<h1 align=center><img alt="Description" title="Toolchain Description" src="https://raw.githubusercontent.com/abhiTronix/Imbakup/master/Images/gcc/gcc_desktop-x86.png"></h1>
+
+### TL'DR
+
+**What is this project?**
+
+> _This project provides the latest, CI maintained, precompiled [**Raspberry Pi CPU optimized**](#optimization-flags-involved) GCC Cross & Native (ARM & ARM64) Compressed Standalone Toolchains, that is [**fastest to setup**](#e-toolchain-setup-documentation) and saves you tons of time and thereby helps you to get quickly started with software development with Pi._
+
+**Who will benefit from the project?**
+
+> _This project benefits everyone, from a professional Developer to a small Hobbyist to a research Student, who's looking for latest easy-to-use precompiled GCC toolchains and build-scripts for there Raspberry Pi project(s)._ 
+
+
+<br>
+
+-------------------------
+
+<br>
+
+This project now utilizes powerful [**Github Actions**][git-action] CI(Continuous Integration) to auto-compile Compressed GCC Cross & Native ARM/ARM64 Toolchain binaries and thereby auto-deploy them to SourceForge repository.
+
+<h3 align=center><img alt="Workflow" title="Toolchain Builder Workflow" src="https://raw.githubusercontent.com/abhiTronix/Imbakup/master/Images/gcc/workflow.png"></h3>
+
+
+<br>
+
+-------------------------
+
+<br>
+
+
+## Toolchain Binaries description table:
+
+**Here's a reference table for various CI generated OS targetted precompiled Toolchain Binaries available with this project:**
+
+* **References:**
+  * **Host OS:** on which the toolchain is executed/used.
+  * **Target OS:** for which the toolchain generates code.
+
+<br>
+
+
+| Toolchains | Host OS | Target OS | Current Status | Precompiled GCC versions available |
+| :---------- | :--------: | :-------: | :--------: | :------------------------: |
+| **Raspberry Pi GCC Cross-Compiler Toolchains(Stretch)** | any x64/x86 Linux machine | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 6.3.0,  9.2.0, 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC Cross-Compiler Toolchains(Buster)** | any x64/x86 Linux machine | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 8.3.0, 9.2.0, 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC Native-Compiler Toolchains(Stretch)** | Raspbian Stretch OS (Debian Version 9) only | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC Native-Compiler Toolchains(Buster)** | Raspbian Buster OS (Debian Version 10) only | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC 64-Bit Cross-Compiler Toolchains** | any x64/x86 Linux machine | any x64 Raspberry Pi OS(like Pi64) | Stable/Production | 6.3.0, 8.3.0, 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC 64-Bit Native-Compiler Toolchains** | any x64 Raspberry Pi OS(like Pi64) | any x64 Raspbian OS(like Pi64) | Stable/Production | 8.3.0, 9.3.0, 10.1.0 |
+| **Exclusive/Experimental Toolchains** |  None | None | Beta/Experimental | None |  
+ 
+
+
+**Tip:** _To get the location of each Binary of this project on SourceForge, you can also check out [this Reference Tree](https://github.com/abhiTronix/raspberry-pi-cross-compilers/wiki/Toolchain-Binaries-Reference-Tree#toolchain-binaries-reference-tree)._
+
+<br>
+
+-------------------------
+
+<br>
+
+
+## Toolchain Setup Documentation:
+
+These precompiled toolchains setup requires just three easy steps - **Downloading, Extracting and Linking**:
+
+* #### [WIKI-Documentation (en-English)](https://github.com/abhiTronix/raspberry-pi-cross-compilers/wiki)
+
+<br>
+
+-------------------------
+
+<br>
+
+## Supported Toolchains Programming Languages:
+- C++
+- Fortran
+- C
+- Any other language support can be easily [compiled](#scroll-build-scripts).
+ 
+<br>
+
+-------------------------
+
+<br>
+
+
+## Supporting this Project
+
+**If these binaries helped you big time, please consider supporting it through any size donations.**
+
+[![Donate](https://img.shields.io/badge/Donate-PayPal-green.svg?logo=paypal&style=for-the-badge)](https://paypal.me/AbhiTronix)
+
+***You can also share your [**thoughts**](https://sourceforge.net/projects/raspberry-pi-cross-compilers/reviews) or just drop a [star](https://github.com/abhiTronix/raspberry-pi-cross-compilers/stargazers).***
+
+<br>
+
+-------------------------
+
+<br>
+
+
+# Additional Information
+
+### Supported ARM Devices:
+
+- All Raspberry Pi hardware/versions/models are currently supported. 
+- Any other ARM Device(such as android, IoT) with similar Hardware architecture(see [Optimization Flags](#optimization-flags-involved)) should also work.
+
+### Optimization Flags Involved:
+
+**These toolchains are built with these following system-specific LTO _(Link Time Optimization)_ flags, therefore you can easily take advantage of your Raspberry Pi's CPU specific features with these Toolchains while compiling your programs:**
+
+**Important:** The latest Raspberry Pi 4 uses a Broadcom BCM2711 SoC with a 1.5 GHz 64-bit quad-core ARM Cortex-A72 processor, that also have armv8-a architecture similar to Raspberry Pi 3B+, therefore it is also officially supported!
+
+| Raspberry Pi Board | Link Time Optimization Flags |
+|---|---|
+| Raspberry Pi - *Zero/W/WH & 1 Model A/B/A+/B+* | `-march=armv6 -mfloat-abi=hard -mfpu=vfp` |
+| Raspberry Pi - *2 & 3 Model A/B* | `-march=armv7-a -mfloat-abi=hard -mfpu=neon-vfpv4` |
+| Raspberry Pi - *3 & 4 Model A+/B+ & Compute 3/3-lite/3+ (32-Bit)* | `-march=armv8-a -mfloat-abi=hard -mfpu=neon-fp-armv8` |
+| Raspberry Pi - *3 & 4 Model A+/B+ & Compute 3/3-lite/3+ (64-Bit)* | `-march=armv8-a+fp+simd` |
+
+
+<br>
+
+-------------------------
+
+<br> 
+
+
+## Citing
+
+**Here is a Bibtex entry you can use to cite this project in a publication:**
+
+```BibTeX
+@misc{raspberry-pi-cross-compilers,
+    Title = {Raspberry Pi Toolchains},
+    Author = {Abhishek Thakur},
+    howpublished = {\url{https://github.com/abhiTronix/raspberry-pi-cross-compilers}},
+    year = {2020}  
+  }
+```
+
+
+<br>
+
+-------------------------
+
+<br> 
+
+
+## Copyright License
+
+**Copyright © 2020 abhiTronix**
+
+This Project source-code and its precompiled binaries are licensed under the [**GPLv3**][license] license.
+
+<br>
+
+-------------------------
+
+<br> 
+ 
+
+## Acknowledgments
+
+Thank you,
+
+- [GNU project][gnu] for providing the latest source code.   
+- [Raspberry Pi project][pi-project] for providing the latest kernel and docs.  
+- [GitHub Actions][git-action] for making it easier to automate Toolchain Builder workflows.
+- [Sourceforge project][sf-project]  for allowing me to publish these binaries.
+
+
+
+[downloads-badge]:https://img.shields.io/sourceforge/dt/raspberry-pi-cross-compilers?style=for-the-badge&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAALQAAAC0CAMAAAAKE/YAAAAAYFBMVEVHcEz/OwDzfCD0fCDzfCDzfR/zfCD9fiHzfCD0fCDzfCD0fSDzeyDzfB/zfCDzfCDzfCD/WgPzfCDxfx7wfCH0fCDzfCDzfCDzfB/zfCDzfCD0fCDzfCDyfCD1fCDzfCAr6LXeAAAAH3RSTlMAAXuI/oNpCPhIlYq2oYC37wN2IRDO5sI926lfUycyJgWG0gAABKZJREFUeAHt3P9Os0gUxvEzOhZobUvL71r73P9dbkzfJcW3wPCcnRzN8v1b48cjhWEmUdbW1tbW1tbWPrr8WVUrP7cXjJSXv88MZL/Q7IvfZ8aL/MzOGG+3mlfzal7N/0vzpq43Yt5hkfkN8Dj8OvNXh19mJtTmZnM1YTZXE2ZzNWE2VxNmczVhNlcTZls1YT4Tr2HWZpfDUk2Yp9E4/FDz9De8/FCzuK2BmjBbqgmzvZow26t5M6+2N9ur3wgzobYw82p7860g1MbmA9JMvneaVJubpUKvNpr1tPlVntQBSFti1kbmHo2cuK4NzVIDgK+Sv9X7KbWpucS9vRBqI7Nrcc9fCbWFeXBAV5eE2sbsKvzJb4VQW5jlhj7fEmoLszyYfOUItYH50+Ohq8RX683yjscqF1+tN18xLBOlOr75VNYY1ohOHd8s7h3fu8nTTryaN4ceLPqtqNTxzZnHX+WJRh3fXOR40lV4dXxzUuFZF6HV8c1ywbN8mtDq+OYzRroKqY5vbj1G2gqrjm0uaozVCa2Oa3ZHjPfJq2Oa5YyJNsKrI875M8V4fi/R1LxZXIOpOtGoI5nlA5P5sv/COluq9i9xzGWO6Vr50wbdiZs1b57eMwj4JLbAh3Cz5s3EoAePl9Kjc/rrWm+WM2byzePe5FXUs9abXYe5avm3I9Do7yF6c4vZfPKwKeILRn2WQa+0uXfMVjz+sIOo1TvludUpx3yt3HMbAJ3Tqs8YrzrJfDcE1N/nNv2voFFPzelN5nMvmM+fB8/OnSjVuXY52yCgtwG6EqX6gPEaJ/PVCGg7QPtSRnMharenFsJ9JUK6DK5pZKKc9dQ5mZ9XtwjpOFymHGQiF1/9gZCa4Q32ImI66/MitLvcDwhkMne6YLyNXv2GkHpl169FJitrjPehVbvdInTi8VUqc+0Cll+8eo+Qum8f25PmvSIVQs2je0spMx0nb/qEmkDncq8JnPQV470nolXvMN3gL1p4fOVTmS5LQ8y8+oCgisHVUevMjJp4uPhMRFxS416jN6vULYLaDd6R9nqzSl16hFSXj8dIZ71Zp64QVJMdeg1atXnYUrXbYnFpojPrZ33F4t6VZv2skxxL+9Ca9bPeY2FpqTXrZ33DwrZ6s37WDRblP/Vm/awzLOoSwUzM+ogFpZ+sWT/ribOt6XZRzMSsXxBcl0QxE7M+NQgsvfHmoF7D1UWNsDaMOZb6lvMXNG/WqtsQ9dYRZmP1jjHHVRdVwM46YY6qduUeE3UtY46o7gk1RvK7hDTHVyebp2x/4Z7d0dU9u8K36h27rouv7vvcvPfzzqvXNhHSHF89rLxl12vWFk793s33NqkmIswGasJspObNdmrebKfmzXZq3myn5s02at58JM282tbMq+3NvJo326l5s52aN9upebOdmjdbqlmzrZozG6uvjNla3RFmc3XqCLO1emttJv7JUZMQZiM1b7ZT82Z7dVMSZiM1b7ZR25uJzuirCLOVmjdbqlmzrZozW6tTHI3NRGUp1mYi5+zNfKt5Na9m+/g9c8tcmVubiTJzM1HhKbP9QuRZfm9vnqgsnvUfk9fW1tbW1tb+AZhQydEXZaX4AAAAAElFTkSuQmCC
+[license-badge]:https://img.shields.io/github/license/abhiTronix/raspberry-pi-cross-compilers.svg?style=for-the-badge
+[kofi-badge]:https://www.ko-fi.com/img/githubbutton_sm.svg
+
+[downloads]:https://sourceforge.net/projects/raspberry-pi-cross-compilers
+[license]:https://github.com/abhiTronix/raspberry-pi-cross-compilers/blob/master/LICENSE
+[kofi]:https://ko-fi.com/W7W8WTYO
+[gnu]:https://gcc.gnu.org/
+[pi-project]:https://www.raspberrypi.org/
+[sf-project]:https://sourceforge.net
+[git-action]:https://github.com/features/actions
+[tar]:https://www.gnu.org/software/tar/
+[pigz]:https://zlib.net/pigz/
+
+[cc-stretch-630]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Stretch/GCC%206.3.0/
+[cc-stretch-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Stretch/GCC%209.2.0/
+[cc-buster-830]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Buster/GCC%208.3.0/
+[cc-buster-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Buster/GCC%209.2.0/
+[nc-stretch-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Native-Compiler%20Toolchains/Stretch/
+[nc-buster-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Native-Compiler%20Toolchains/Buster/
+[cc-64-630]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Bonus%20Raspberry%20Pi%20GCC%2064-Bit%20Toolchains/Raspberry%20Pi%20GCC%2064-Bit%20Cross-Compiler%20Toolchains/GCC%206.3.0/
+[cc-64-830]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Bonus%20Raspberry%20Pi%20GCC%2064-Bit%20Toolchains/Raspberry%20Pi%20GCC%2064-Bit%20Cross-Compiler%20Toolchains/GCC%208.3.0/
+[cc-64-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Bonus%20Raspberry%20Pi%20GCC%2064-Bit%20Toolchains/Raspberry%20Pi%20GCC%2064-Bit%20Cross-Compiler%20Toolchains/GCC%209.2.0/
+[nc-64-830]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Bonus%20Raspberry%20Pi%20GCC%2064-Bit%20Toolchains/Raspberry%20Pi%20GCC%2064-Bit%20Native-Compiler%20Toolchains/GCC%208.3.0/
+[nc-64-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Bonus%20Raspberry%20Pi%20GCC%2064-Bit%20Toolchains/Raspberry%20Pi%20GCC%2064-Bit%20Native-Compiler%20Toolchains/GCC%209.2.0/

--- a/docs/desktop-gcc-x86_64.md
+++ b/docs/desktop-gcc-x86_64.md
@@ -1,0 +1,229 @@
+<!--
+===============================================
+Raspberry Pi Toolchains(raspberry-pi-cross-compilers): This project 
+provides latest automated GCC Cross Compiler & Native (ARM & ARM64) 
+build-scripts and precompiled standalone toolchains for Raspberry Pi.
+
+
+Copyright (C) 2020 Abhishek Thakur(@abhiTronix) <abhi.una12@gmail.com>
+
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+===============================================
+-->
+
+<br>
+
+<h1 align=center><img alt="Description" title="Toolchain Description" src="https://raw.githubusercontent.com/abhiTronix/Imbakup/master/Images/gcc/gcc_desktop-x86_64.png"></h1>
+
+
+### TL'DR
+
+**What is this project?**
+
+> _This project provides the latest, CI maintained, precompiled [**Raspberry Pi CPU optimized**](#optimization-flags-involved) GCC Cross & Native (ARM & ARM64) Compressed Standalone Toolchains, that is [**fastest to setup**](#e-toolchain-setup-documentation) and saves you tons of time and thereby helps you to get quickly started with software development with Pi._
+
+**Who will benefit from the project?**
+
+> _This project benefits everyone, from a professional Developer to a small Hobbyist to a research Student, who's looking for latest easy-to-use precompiled GCC toolchains and build-scripts for there Raspberry Pi project(s)._ 
+
+
+
+<br>
+
+-------------------------
+
+<br>
+
+This project now utilizes powerful [**Github Actions**][git-action] CI(Continuous Integration) to auto-compile Compressed GCC Cross & Native ARM/ARM64 Toolchain binaries and thereby auto-deploy them to SourceForge repository.
+
+<h3 align=center><img alt="Workflow" title="Toolchain Builder Workflow" src="https://raw.githubusercontent.com/abhiTronix/Imbakup/master/Images/gcc/workflow.png"></h3>
+
+
+<br>
+
+-------------------------
+
+<br>
+
+## Toolchain Binaries description table:
+
+**Here's a reference table for various CI generated OS targetted precompiled Toolchain Binaries available with this project:**
+
+* **References:**
+  * **Host OS:** on which the toolchain is executed/used.
+  * **Target OS:** for which the toolchain generates code.
+
+<br>
+
+
+| Toolchains | Host OS | Target OS | Current Status | Precompiled GCC versions available |
+| :---------- | :--------: | :-------: | :--------: | :------------------------: |
+| **Raspberry Pi GCC Cross-Compiler Toolchains(Stretch)** | any x64/x86 Linux machine | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 6.3.0,  9.2.0, 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC Cross-Compiler Toolchains(Buster)** | any x64/x86 Linux machine | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 8.3.0, 9.2.0, 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC Native-Compiler Toolchains(Stretch)** | Raspbian Stretch OS (Debian Version 9) only | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC Native-Compiler Toolchains(Buster)** | Raspbian Buster OS (Debian Version 10) only | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC 64-Bit Cross-Compiler Toolchains** | any x64/x86 Linux machine | any x64 Raspberry Pi OS(like Pi64) | Stable/Production | 6.3.0, 8.3.0, 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC 64-Bit Native-Compiler Toolchains** | any x64 Raspberry Pi OS(like Pi64) | any x64 Raspbian OS(like Pi64) | Stable/Production | 8.3.0, 9.3.0, 10.1.0 |
+| **Exclusive/Experimental Toolchains** |  None | None | Beta/Experimental | None | 
+
+
+**Tip:** _To get the location of each Binary of this project on SourceForge, you can also check out [this Reference Tree](https://github.com/abhiTronix/raspberry-pi-cross-compilers/wiki/Toolchain-Binaries-Reference-Tree#toolchain-binaries-reference-tree)._
+
+
+<br>
+
+-------------------------
+
+<br>
+
+
+## Toolchain Setup Documentation:
+
+These precompiled toolchains setup requires just three easy steps - **Downloading, Extracting and Linking**:
+
+* #### [WIKI-Documentation (en-English)](https://github.com/abhiTronix/raspberry-pi-cross-compilers/wiki)
+
+<br>
+
+-------------------------
+
+<br>
+
+## Supported Toolchains Programming Languages:
+- C++
+- Fortran
+- C
+- Any other language support can be easily [compiled](#scroll-build-scripts).
+ 
+<br>
+
+-------------------------
+
+<br>
+
+
+## Supporting this Project
+
+**If these binaries helped you big time, please consider supporting it through any size donations.**
+
+[![Donate](https://img.shields.io/badge/Donate-PayPal-green.svg?logo=paypal&style=for-the-badge)](https://paypal.me/AbhiTronix)
+
+***You can also share your [**thoughts**](https://sourceforge.net/projects/raspberry-pi-cross-compilers/reviews) or just drop a [star](https://github.com/abhiTronix/raspberry-pi-cross-compilers/stargazers).***
+
+<br>
+
+-------------------------
+
+<br>
+
+
+# Additional Information
+
+### Supported ARM Devices:
+
+- All Raspberry Pi hardware/versions/models are currently supported. 
+- Any other ARM Device(such as android, IoT) with similar Hardware architecture(see [Optimization Flags](#optimization-flags-involved)) should also work.
+
+### Optimization Flags Involved:
+
+**These toolchains are built with these following system-specific LTO _(Link Time Optimization)_ flags, therefore you can easily take advantage of your Raspberry Pi's CPU specific features with these Toolchains while compiling your programs:**
+
+**Important:** The latest Raspberry Pi 4 uses a Broadcom BCM2711 SoC with a 1.5 GHz 64-bit quad-core ARM Cortex-A72 processor, that also have armv8-a architecture similar to Raspberry Pi 3B+, therefore it is also officially supported!
+
+| Raspberry Pi Board | Link Time Optimization Flags |
+|---|---|
+| Raspberry Pi - *Zero/W/WH & 1 Model A/B/A+/B+* | `-march=armv6 -mfloat-abi=hard -mfpu=vfp` |
+| Raspberry Pi - *2 & 3 Model A/B* | `-march=armv7-a -mfloat-abi=hard -mfpu=neon-vfpv4` |
+| Raspberry Pi - *3 & 4 Model A+/B+ & Compute 3/3-lite/3+ (32-Bit)* | `-march=armv8-a -mfloat-abi=hard -mfpu=neon-fp-armv8` |
+| Raspberry Pi - *3 & 4 Model A+/B+ & Compute 3/3-lite/3+ (64-Bit)* | `-march=armv8-a+fp+simd` |
+
+
+<br>
+
+-------------------------
+
+<br> 
+
+
+## Citing
+
+**Here is a Bibtex entry you can use to cite this project in a publication:**
+
+```BibTeX
+@misc{raspberry-pi-cross-compilers,
+    Title = {Raspberry Pi Toolchains},
+    Author = {Abhishek Thakur},
+    howpublished = {\url{https://github.com/abhiTronix/raspberry-pi-cross-compilers}},
+    year = {2020}  
+  }
+```
+
+
+<br>
+
+-------------------------
+
+<br> 
+
+
+## Copyright License
+
+**Copyright © 2020 abhiTronix**
+
+This Project source-code and its precompiled binaries are licensed under the [**GPLv3**][license] license.
+
+<br>
+
+-------------------------
+
+<br> 
+ 
+
+## Acknowledgments
+
+Thank you,
+
+- [GNU project][gnu] for providing the latest source code.   
+- [Raspberry Pi project][pi-project] for providing the latest kernel and docs.  
+- [GitHub Actions][git-action] for making it easier to automate Toolchain Builder workflows.
+- [Sourceforge project][sf-project]  for allowing me to publish these binaries.
+
+
+
+[downloads-badge]:https://img.shields.io/sourceforge/dt/raspberry-pi-cross-compilers?style=for-the-badge&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAALQAAAC0CAMAAAAKE/YAAAAAYFBMVEVHcEz/OwDzfCD0fCDzfCDzfR/zfCD9fiHzfCD0fCDzfCD0fSDzeyDzfB/zfCDzfCDzfCD/WgPzfCDxfx7wfCH0fCDzfCDzfCDzfB/zfCDzfCD0fCDzfCDyfCD1fCDzfCAr6LXeAAAAH3RSTlMAAXuI/oNpCPhIlYq2oYC37wN2IRDO5sI926lfUycyJgWG0gAABKZJREFUeAHt3P9Os0gUxvEzOhZobUvL71r73P9dbkzfJcW3wPCcnRzN8v1b48cjhWEmUdbW1tbW1tbWPrr8WVUrP7cXjJSXv88MZL/Q7IvfZ8aL/MzOGG+3mlfzal7N/0vzpq43Yt5hkfkN8Dj8OvNXh19mJtTmZnM1YTZXE2ZzNWE2VxNmczVhNlcTZls1YT4Tr2HWZpfDUk2Yp9E4/FDz9De8/FCzuK2BmjBbqgmzvZow26t5M6+2N9ur3wgzobYw82p7860g1MbmA9JMvneaVJubpUKvNpr1tPlVntQBSFti1kbmHo2cuK4NzVIDgK+Sv9X7KbWpucS9vRBqI7Nrcc9fCbWFeXBAV5eE2sbsKvzJb4VQW5jlhj7fEmoLszyYfOUItYH50+Ohq8RX683yjscqF1+tN18xLBOlOr75VNYY1ohOHd8s7h3fu8nTTryaN4ceLPqtqNTxzZnHX+WJRh3fXOR40lV4dXxzUuFZF6HV8c1ywbN8mtDq+OYzRroKqY5vbj1G2gqrjm0uaozVCa2Oa3ZHjPfJq2Oa5YyJNsKrI875M8V4fi/R1LxZXIOpOtGoI5nlA5P5sv/COluq9i9xzGWO6Vr50wbdiZs1b57eMwj4JLbAh3Cz5s3EoAePl9Kjc/rrWm+WM2byzePe5FXUs9abXYe5avm3I9Do7yF6c4vZfPKwKeILRn2WQa+0uXfMVjz+sIOo1TvludUpx3yt3HMbAJ3Tqs8YrzrJfDcE1N/nNv2voFFPzelN5nMvmM+fB8/OnSjVuXY52yCgtwG6EqX6gPEaJ/PVCGg7QPtSRnMharenFsJ9JUK6DK5pZKKc9dQ5mZ9XtwjpOFymHGQiF1/9gZCa4Q32ImI66/MitLvcDwhkMne6YLyNXv2GkHpl169FJitrjPehVbvdInTi8VUqc+0Cll+8eo+Qum8f25PmvSIVQs2je0spMx0nb/qEmkDncq8JnPQV470nolXvMN3gL1p4fOVTmS5LQ8y8+oCgisHVUevMjJp4uPhMRFxS416jN6vULYLaDd6R9nqzSl16hFSXj8dIZ71Zp64QVJMdeg1atXnYUrXbYnFpojPrZ33F4t6VZv2skxxL+9Ca9bPeY2FpqTXrZ33DwrZ6s37WDRblP/Vm/awzLOoSwUzM+ogFpZ+sWT/ribOt6XZRzMSsXxBcl0QxE7M+NQgsvfHmoF7D1UWNsDaMOZb6lvMXNG/WqtsQ9dYRZmP1jjHHVRdVwM46YY6qduUeE3UtY46o7gk1RvK7hDTHVyebp2x/4Z7d0dU9u8K36h27rouv7vvcvPfzzqvXNhHSHF89rLxl12vWFk793s33NqkmIswGasJspObNdmrebKfmzXZq3myn5s02at58JM282tbMq+3NvJo326l5s52aN9upebOdmjdbqlmzrZozG6uvjNla3RFmc3XqCLO1emttJv7JUZMQZiM1b7ZT82Z7dVMSZiM1b7ZR25uJzuirCLOVmjdbqlmzrZozW6tTHI3NRGUp1mYi5+zNfKt5Na9m+/g9c8tcmVubiTJzM1HhKbP9QuRZfm9vnqgsnvUfk9fW1tbW1tb+AZhQydEXZaX4AAAAAElFTkSuQmCC
+[license-badge]:https://img.shields.io/github/license/abhiTronix/raspberry-pi-cross-compilers.svg?style=for-the-badge
+[kofi-badge]:https://www.ko-fi.com/img/githubbutton_sm.svg
+
+[downloads]:https://sourceforge.net/projects/raspberry-pi-cross-compilers
+[license]:https://github.com/abhiTronix/raspberry-pi-cross-compilers/blob/master/LICENSE
+[kofi]:https://ko-fi.com/W7W8WTYO
+[gnu]:https://gcc.gnu.org/
+[pi-project]:https://www.raspberrypi.org/
+[sf-project]:https://sourceforge.net
+[git-action]:https://github.com/features/actions
+[tar]:https://www.gnu.org/software/tar/
+[pigz]:https://zlib.net/pigz/
+
+[cc-stretch-630]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Stretch/GCC%206.3.0/
+[cc-stretch-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Stretch/GCC%209.2.0/
+[cc-buster-830]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Buster/GCC%208.3.0/
+[cc-buster-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Buster/GCC%209.2.0/
+[nc-stretch-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Native-Compiler%20Toolchains/Stretch/
+[nc-buster-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Native-Compiler%20Toolchains/Buster/
+[cc-64-630]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Bonus%20Raspberry%20Pi%20GCC%2064-Bit%20Toolchains/Raspberry%20Pi%20GCC%2064-Bit%20Cross-Compiler%20Toolchains/GCC%206.3.0/
+[cc-64-830]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Bonus%20Raspberry%20Pi%20GCC%2064-Bit%20Toolchains/Raspberry%20Pi%20GCC%2064-Bit%20Cross-Compiler%20Toolchains/GCC%208.3.0/
+[cc-64-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Bonus%20Raspberry%20Pi%20GCC%2064-Bit%20Toolchains/Raspberry%20Pi%20GCC%2064-Bit%20Cross-Compiler%20Toolchains/GCC%209.2.0/
+[nc-64-830]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Bonus%20Raspberry%20Pi%20GCC%2064-Bit%20Toolchains/Raspberry%20Pi%20GCC%2064-Bit%20Native-Compiler%20Toolchains/GCC%208.3.0/
+[nc-64-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Bonus%20Raspberry%20Pi%20GCC%2064-Bit%20Toolchains/Raspberry%20Pi%20GCC%2064-Bit%20Native-Compiler%20Toolchains/GCC%209.2.0/

--- a/docs/desktop-gcc-x86_64.md
+++ b/docs/desktop-gcc-x86_64.md
@@ -70,13 +70,13 @@ This project now utilizes powerful [**Github Actions**][git-action] CI(Continuou
 
 | Toolchains | Host OS | Target OS | Current Status | Precompiled GCC versions available |
 | :---------- | :--------: | :-------: | :--------: | :------------------------: |
-| **Raspberry Pi GCC Cross-Compiler Toolchains(Stretch)** | any x64/x86 Linux machine | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 6.3.0,  9.2.0, 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC Cross-Compiler Toolchains(Buster)** | any x64/x86 Linux machine | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 8.3.0, 9.2.0, 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC Native-Compiler Toolchains(Stretch)** | Raspbian Stretch OS (Debian Version 9) only | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC Native-Compiler Toolchains(Buster)** | Raspbian Buster OS (Debian Version 10) only | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC 64-Bit Cross-Compiler Toolchains** | any x64/x86 Linux machine | any x64 Raspberry Pi OS(like Pi64) | Stable/Production | 6.3.0, 8.3.0, 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC 64-Bit Native-Compiler Toolchains** | any x64 Raspberry Pi OS(like Pi64) | any x64 Raspbian OS(like Pi64) | Stable/Production | 8.3.0, 9.3.0, 10.1.0 |
-| **Exclusive/Experimental Toolchains** |  None | None | Beta/Experimental | None | 
+| **Raspberry Pi GCC Cross-Compiler Toolchains(Stretch)** | any x64/x86 Linux machine | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 6.3.0,  9.3.0, 10.2.0 |
+| **Raspberry Pi GCC Cross-Compiler Toolchains(Buster)** | any x64/x86 Linux machine | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 8.3.0, 9.3.0, 10.2.0 |
+| **Raspberry Pi GCC Native-Compiler Toolchains(Stretch)** | Raspbian Stretch OS (Debian Version 9) only | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 9.3.0, 10.2.0 |
+| **Raspberry Pi GCC Native-Compiler Toolchains(Buster)** | Raspbian Buster OS (Debian Version 10) only | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 9.3.0, 10.2.0 |
+| **Raspberry Pi GCC 64-Bit Cross-Compiler Toolchains** | any x64/x86 Linux machine | any x64 Raspberry Pi OS(like Pi64) | Stable/Production | 6.3.0, 8.3.0, 9.3.0, 10.2.0 |
+| **Raspberry Pi GCC 64-Bit Native-Compiler Toolchains** | any x64 Raspberry Pi OS(like Pi64) | any x64 Raspbian OS(like Pi64) | Stable/Production | 8.3.0, 9.3.0, 10.2.0 |
+| **Exclusive/Experimental Toolchains** |  x86/x86_64 Pi Desktop | x86/x86_64 Pi Desktop | Beta/Experimental | 10.2.0 | 
 
 
 **Tip:** _To get the location of each Binary of this project on SourceForge, you can also check out [this Reference Tree](https://github.com/abhiTronix/raspberry-pi-cross-compilers/wiki/Toolchain-Binaries-Reference-Tree#toolchain-binaries-reference-tree)._
@@ -217,9 +217,9 @@ Thank you,
 [pigz]:https://zlib.net/pigz/
 
 [cc-stretch-630]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Stretch/GCC%206.3.0/
-[cc-stretch-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Stretch/GCC%209.2.0/
+
 [cc-buster-830]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Buster/GCC%208.3.0/
-[cc-buster-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Buster/GCC%209.2.0/
+
 [nc-stretch-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Native-Compiler%20Toolchains/Stretch/
 [nc-buster-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Native-Compiler%20Toolchains/Buster/
 [cc-64-630]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Bonus%20Raspberry%20Pi%20GCC%2064-Bit%20Toolchains/Raspberry%20Pi%20GCC%2064-Bit%20Cross-Compiler%20Toolchains/GCC%206.3.0/

--- a/docs/desktop-gcc.md
+++ b/docs/desktop-gcc.md
@@ -70,13 +70,13 @@ This project now utilizes powerful [**Github Actions**][git-action] CI(Continuou
 
 | Toolchains | Host OS | Target OS | Current Status | Precompiled GCC versions available |
 | :---------- | :--------: | :-------: | :--------: | :------------------------: |
-| **Raspberry Pi GCC Cross-Compiler Toolchains(Stretch)** | any x64/x86 Linux machine | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 6.3.0,  9.2.0, 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC Cross-Compiler Toolchains(Buster)** | any x64/x86 Linux machine | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 8.3.0, 9.2.0, 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC Native-Compiler Toolchains(Stretch)** | Raspbian Stretch OS (Debian Version 9) only | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC Native-Compiler Toolchains(Buster)** | Raspbian Buster OS (Debian Version 10) only | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC 64-Bit Cross-Compiler Toolchains** | any x64/x86 Linux machine | any x64 Raspberry Pi OS(like Pi64) | Stable/Production | 6.3.0, 8.3.0, 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC 64-Bit Native-Compiler Toolchains** | any x64 Raspberry Pi OS(like Pi64) | any x64 Raspbian OS(like Pi64) | Stable/Production | 8.3.0, 9.3.0, 10.1.0 |
-| **Exclusive/Experimental Toolchains** |  None | None | Beta/Experimental | None | 
+| **Raspberry Pi GCC Cross-Compiler Toolchains(Stretch)** | any x64/x86 Linux machine | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 6.3.0,  9.3.0, 10.2.0 |
+| **Raspberry Pi GCC Cross-Compiler Toolchains(Buster)** | any x64/x86 Linux machine | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 8.3.0, 9.3.0, 10.2.0 |
+| **Raspberry Pi GCC Native-Compiler Toolchains(Stretch)** | Raspbian Stretch OS (Debian Version 9) only | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 9.3.0, 10.2.0 |
+| **Raspberry Pi GCC Native-Compiler Toolchains(Buster)** | Raspbian Buster OS (Debian Version 10) only | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 9.3.0, 10.2.0 |
+| **Raspberry Pi GCC 64-Bit Cross-Compiler Toolchains** | any x64/x86 Linux machine | any x64 Raspberry Pi OS(like Pi64) | Stable/Production | 6.3.0, 8.3.0, 9.3.0, 10.2.0 |
+| **Raspberry Pi GCC 64-Bit Native-Compiler Toolchains** | any x64 Raspberry Pi OS(like Pi64) | any x64 Raspbian OS(like Pi64) | Stable/Production | 8.3.0, 9.3.0, 10.2.0 |
+| **Exclusive/Experimental Toolchains** |  x86/x86_64 Pi Desktop | x86/x86_64 Pi Desktop | Beta/Experimental | 10.2.0 | 
 
 
 **Tip:** _To get the location of each Binary of this project on SourceForge, you can also check out [this Reference Tree](https://github.com/abhiTronix/raspberry-pi-cross-compilers/wiki/Toolchain-Binaries-Reference-Tree#toolchain-binaries-reference-tree)._
@@ -217,9 +217,9 @@ Thank you,
 [pigz]:https://zlib.net/pigz/
 
 [cc-stretch-630]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Stretch/GCC%206.3.0/
-[cc-stretch-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Stretch/GCC%209.2.0/
+
 [cc-buster-830]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Buster/GCC%208.3.0/
-[cc-buster-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Buster/GCC%209.2.0/
+
 [nc-stretch-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Native-Compiler%20Toolchains/Stretch/
 [nc-buster-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Native-Compiler%20Toolchains/Buster/
 [cc-64-630]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Bonus%20Raspberry%20Pi%20GCC%2064-Bit%20Toolchains/Raspberry%20Pi%20GCC%2064-Bit%20Cross-Compiler%20Toolchains/GCC%206.3.0/

--- a/docs/desktop-gcc.md
+++ b/docs/desktop-gcc.md
@@ -1,0 +1,229 @@
+<!--
+===============================================
+Raspberry Pi Toolchains(raspberry-pi-cross-compilers): This project 
+provides latest automated GCC Cross Compiler & Native (ARM & ARM64) 
+build-scripts and precompiled standalone toolchains for Raspberry Pi.
+
+
+Copyright (C) 2020 Abhishek Thakur(@abhiTronix) <abhi.una12@gmail.com>
+
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+===============================================
+-->
+
+<br>
+
+<h1 align=center><img alt="Description" title="Toolchain Description" src="https://github.com/abhiTronix/Imbakup/raw/master/Images/gcc/gcc_desktop.png"></h1>
+
+
+### TL'DR
+
+**What is this project?**
+
+> _This project provides the latest, CI maintained, precompiled [**Raspberry Pi CPU optimized**](#optimization-flags-involved) GCC Cross & Native (ARM & ARM64) Compressed Standalone Toolchains, that is [**fastest to setup**](#e-toolchain-setup-documentation) and saves you tons of time and thereby helps you to get quickly started with software development with Pi._
+
+**Who will benefit from the project?**
+
+> _This project benefits everyone, from a professional Developer to a small Hobbyist to a research Student, who's looking for latest easy-to-use precompiled GCC toolchains and build-scripts for there Raspberry Pi project(s)._ 
+
+
+
+<br>
+
+-------------------------
+
+<br>
+
+
+This project now utilizes powerful [**Github Actions**][git-action] CI(Continuous Integration) to auto-compile Compressed GCC Cross & Native ARM/ARM64 Toolchain binaries and thereby auto-deploy them to SourceForge repository.
+
+<h3 align=center><img alt="Workflow" title="Toolchain Builder Workflow" src="https://raw.githubusercontent.com/abhiTronix/Imbakup/master/Images/gcc/workflow.png"></h3>
+
+
+<br>
+
+-------------------------
+
+<br>
+
+## Toolchain Binaries description table:
+
+**Here's a reference table for various CI generated OS targetted precompiled Toolchain Binaries available with this project:**
+
+* **References:**
+  * **Host OS:** on which the toolchain is executed/used.
+  * **Target OS:** for which the toolchain generates code.
+
+<br>
+
+| Toolchains | Host OS | Target OS | Current Status | Precompiled GCC versions available |
+| :---------- | :--------: | :-------: | :--------: | :------------------------: |
+| **Raspberry Pi GCC Cross-Compiler Toolchains(Stretch)** | any x64/x86 Linux machine | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 6.3.0,  9.2.0, 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC Cross-Compiler Toolchains(Buster)** | any x64/x86 Linux machine | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 8.3.0, 9.2.0, 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC Native-Compiler Toolchains(Stretch)** | Raspbian Stretch OS (Debian Version 9) only | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC Native-Compiler Toolchains(Buster)** | Raspbian Buster OS (Debian Version 10) only | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC 64-Bit Cross-Compiler Toolchains** | any x64/x86 Linux machine | any x64 Raspberry Pi OS(like Pi64) | Stable/Production | 6.3.0, 8.3.0, 9.3.0, 10.1.0 |
+| **Raspberry Pi GCC 64-Bit Native-Compiler Toolchains** | any x64 Raspberry Pi OS(like Pi64) | any x64 Raspbian OS(like Pi64) | Stable/Production | 8.3.0, 9.3.0, 10.1.0 |
+| **Exclusive/Experimental Toolchains** |  None | None | Beta/Experimental | None | 
+
+
+**Tip:** _To get the location of each Binary of this project on SourceForge, you can also check out [this Reference Tree](https://github.com/abhiTronix/raspberry-pi-cross-compilers/wiki/Toolchain-Binaries-Reference-Tree#toolchain-binaries-reference-tree)._
+
+
+<br>
+
+-------------------------
+
+<br>
+
+
+## Toolchain Setup Documentation:
+
+These precompiled toolchains setup requires just three easy steps - **Downloading, Extracting and Linking**:
+
+* #### [WIKI-Documentation (en-English)](https://github.com/abhiTronix/raspberry-pi-cross-compilers/wiki)
+
+<br>
+
+-------------------------
+
+<br>
+
+## Supported Toolchains Programming Languages:
+- C++
+- Fortran
+- C
+- Any other language support can be easily [compiled](#scroll-build-scripts).
+ 
+<br>
+
+-------------------------
+
+<br>
+
+
+## Supporting this Project
+
+**If these binaries helped you big time, please consider supporting it through any size donations.**
+
+[![Donate](https://img.shields.io/badge/Donate-PayPal-green.svg?logo=paypal&style=for-the-badge)](https://paypal.me/AbhiTronix)
+
+***You can also share your [**thoughts**](https://sourceforge.net/projects/raspberry-pi-cross-compilers/reviews) or just drop a [star](https://github.com/abhiTronix/raspberry-pi-cross-compilers/stargazers).***
+
+<br>
+
+-------------------------
+
+<br>
+
+
+# Additional Information
+
+### Supported ARM Devices:
+
+- All Raspberry Pi hardware/versions/models are currently supported. 
+- Any other ARM Device(such as android, IoT) with similar Hardware architecture(see [Optimization Flags](#optimization-flags-involved)) should also work.
+
+### Optimization Flags Involved:
+
+**These toolchains are built with these following system-specific LTO _(Link Time Optimization)_ flags, therefore you can easily take advantage of your Raspberry Pi's CPU specific features with these Toolchains while compiling your programs:**
+
+**Important:** The latest Raspberry Pi 4 uses a Broadcom BCM2711 SoC with a 1.5 GHz 64-bit quad-core ARM Cortex-A72 processor, that also have armv8-a architecture similar to Raspberry Pi 3B+, therefore it is also officially supported!
+
+| Raspberry Pi Board | Link Time Optimization Flags |
+|---|---|
+| Raspberry Pi - *Zero/W/WH & 1 Model A/B/A+/B+* | `-march=armv6 -mfloat-abi=hard -mfpu=vfp` |
+| Raspberry Pi - *2 & 3 Model A/B* | `-march=armv7-a -mfloat-abi=hard -mfpu=neon-vfpv4` |
+| Raspberry Pi - *3 & 4 Model A+/B+ & Compute 3/3-lite/3+ (32-Bit)* | `-march=armv8-a -mfloat-abi=hard -mfpu=neon-fp-armv8` |
+| Raspberry Pi - *3 & 4 Model A+/B+ & Compute 3/3-lite/3+ (64-Bit)* | `-march=armv8-a+fp+simd` |
+
+
+<br>
+
+-------------------------
+
+<br> 
+
+
+## Citing
+
+**Here is a Bibtex entry you can use to cite this project in a publication:**
+
+```BibTeX
+@misc{raspberry-pi-cross-compilers,
+    Title = {Raspberry Pi Toolchains},
+    Author = {Abhishek Thakur},
+    howpublished = {\url{https://github.com/abhiTronix/raspberry-pi-cross-compilers}},
+    year = {2020}  
+  }
+```
+
+
+<br>
+
+-------------------------
+
+<br> 
+
+
+## Copyright License
+
+**Copyright © 2020 abhiTronix**
+
+This Project source-code and its precompiled binaries are licensed under the [**GPLv3**][license] license.
+
+<br>
+
+-------------------------
+
+<br> 
+ 
+
+## Acknowledgments
+
+Thank you,
+
+- [GNU project][gnu] for providing the latest source code.   
+- [Raspberry Pi project][pi-project] for providing the latest kernel and docs.  
+- [GitHub Actions][git-action] for making it easier to automate Toolchain Builder workflows.
+- [Sourceforge project][sf-project]  for allowing me to publish these binaries.
+
+
+
+[downloads-badge]:https://img.shields.io/sourceforge/dt/raspberry-pi-cross-compilers?style=for-the-badge&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAALQAAAC0CAMAAAAKE/YAAAAAYFBMVEVHcEz/OwDzfCD0fCDzfCDzfR/zfCD9fiHzfCD0fCDzfCD0fSDzeyDzfB/zfCDzfCDzfCD/WgPzfCDxfx7wfCH0fCDzfCDzfCDzfB/zfCDzfCD0fCDzfCDyfCD1fCDzfCAr6LXeAAAAH3RSTlMAAXuI/oNpCPhIlYq2oYC37wN2IRDO5sI926lfUycyJgWG0gAABKZJREFUeAHt3P9Os0gUxvEzOhZobUvL71r73P9dbkzfJcW3wPCcnRzN8v1b48cjhWEmUdbW1tbW1tbWPrr8WVUrP7cXjJSXv88MZL/Q7IvfZ8aL/MzOGG+3mlfzal7N/0vzpq43Yt5hkfkN8Dj8OvNXh19mJtTmZnM1YTZXE2ZzNWE2VxNmczVhNlcTZls1YT4Tr2HWZpfDUk2Yp9E4/FDz9De8/FCzuK2BmjBbqgmzvZow26t5M6+2N9ur3wgzobYw82p7860g1MbmA9JMvneaVJubpUKvNpr1tPlVntQBSFti1kbmHo2cuK4NzVIDgK+Sv9X7KbWpucS9vRBqI7Nrcc9fCbWFeXBAV5eE2sbsKvzJb4VQW5jlhj7fEmoLszyYfOUItYH50+Ohq8RX683yjscqF1+tN18xLBOlOr75VNYY1ohOHd8s7h3fu8nTTryaN4ceLPqtqNTxzZnHX+WJRh3fXOR40lV4dXxzUuFZF6HV8c1ywbN8mtDq+OYzRroKqY5vbj1G2gqrjm0uaozVCa2Oa3ZHjPfJq2Oa5YyJNsKrI875M8V4fi/R1LxZXIOpOtGoI5nlA5P5sv/COluq9i9xzGWO6Vr50wbdiZs1b57eMwj4JLbAh3Cz5s3EoAePl9Kjc/rrWm+WM2byzePe5FXUs9abXYe5avm3I9Do7yF6c4vZfPKwKeILRn2WQa+0uXfMVjz+sIOo1TvludUpx3yt3HMbAJ3Tqs8YrzrJfDcE1N/nNv2voFFPzelN5nMvmM+fB8/OnSjVuXY52yCgtwG6EqX6gPEaJ/PVCGg7QPtSRnMharenFsJ9JUK6DK5pZKKc9dQ5mZ9XtwjpOFymHGQiF1/9gZCa4Q32ImI66/MitLvcDwhkMne6YLyNXv2GkHpl169FJitrjPehVbvdInTi8VUqc+0Cll+8eo+Qum8f25PmvSIVQs2je0spMx0nb/qEmkDncq8JnPQV470nolXvMN3gL1p4fOVTmS5LQ8y8+oCgisHVUevMjJp4uPhMRFxS416jN6vULYLaDd6R9nqzSl16hFSXj8dIZ71Zp64QVJMdeg1atXnYUrXbYnFpojPrZ33F4t6VZv2skxxL+9Ca9bPeY2FpqTXrZ33DwrZ6s37WDRblP/Vm/awzLOoSwUzM+ogFpZ+sWT/ribOt6XZRzMSsXxBcl0QxE7M+NQgsvfHmoF7D1UWNsDaMOZb6lvMXNG/WqtsQ9dYRZmP1jjHHVRdVwM46YY6qduUeE3UtY46o7gk1RvK7hDTHVyebp2x/4Z7d0dU9u8K36h27rouv7vvcvPfzzqvXNhHSHF89rLxl12vWFk793s33NqkmIswGasJspObNdmrebKfmzXZq3myn5s02at58JM282tbMq+3NvJo326l5s52aN9upebOdmjdbqlmzrZozG6uvjNla3RFmc3XqCLO1emttJv7JUZMQZiM1b7ZT82Z7dVMSZiM1b7ZR25uJzuirCLOVmjdbqlmzrZozW6tTHI3NRGUp1mYi5+zNfKt5Na9m+/g9c8tcmVubiTJzM1HhKbP9QuRZfm9vnqgsnvUfk9fW1tbW1tb+AZhQydEXZaX4AAAAAElFTkSuQmCC
+[license-badge]:https://img.shields.io/github/license/abhiTronix/raspberry-pi-cross-compilers.svg?style=for-the-badge
+[kofi-badge]:https://www.ko-fi.com/img/githubbutton_sm.svg
+
+[downloads]:https://sourceforge.net/projects/raspberry-pi-cross-compilers
+[license]:https://github.com/abhiTronix/raspberry-pi-cross-compilers/blob/master/LICENSE
+[kofi]:https://ko-fi.com/W7W8WTYO
+[gnu]:https://gcc.gnu.org/
+[pi-project]:https://www.raspberrypi.org/
+[sf-project]:https://sourceforge.net
+[git-action]:https://github.com/features/actions
+[tar]:https://www.gnu.org/software/tar/
+[pigz]:https://zlib.net/pigz/
+
+[cc-stretch-630]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Stretch/GCC%206.3.0/
+[cc-stretch-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Stretch/GCC%209.2.0/
+[cc-buster-830]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Buster/GCC%208.3.0/
+[cc-buster-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Buster/GCC%209.2.0/
+[nc-stretch-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Native-Compiler%20Toolchains/Stretch/
+[nc-buster-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Native-Compiler%20Toolchains/Buster/
+[cc-64-630]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Bonus%20Raspberry%20Pi%20GCC%2064-Bit%20Toolchains/Raspberry%20Pi%20GCC%2064-Bit%20Cross-Compiler%20Toolchains/GCC%206.3.0/
+[cc-64-830]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Bonus%20Raspberry%20Pi%20GCC%2064-Bit%20Toolchains/Raspberry%20Pi%20GCC%2064-Bit%20Cross-Compiler%20Toolchains/GCC%208.3.0/
+[cc-64-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Bonus%20Raspberry%20Pi%20GCC%2064-Bit%20Toolchains/Raspberry%20Pi%20GCC%2064-Bit%20Cross-Compiler%20Toolchains/GCC%209.2.0/
+[nc-64-830]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Bonus%20Raspberry%20Pi%20GCC%2064-Bit%20Toolchains/Raspberry%20Pi%20GCC%2064-Bit%20Native-Compiler%20Toolchains/GCC%208.3.0/
+[nc-64-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Bonus%20Raspberry%20Pi%20GCC%2064-Bit%20Toolchains/Raspberry%20Pi%20GCC%2064-Bit%20Native-Compiler%20Toolchains/GCC%209.2.0/

--- a/docs/gcc64.md
+++ b/docs/gcc64.md
@@ -70,13 +70,13 @@ This project now utilizes powerful [**Github Actions**][git-action] CI(Continuou
 
 | Toolchains | Host OS | Target OS | Current Status | Precompiled GCC versions available |
 | :---------- | :--------: | :-------: | :--------: | :------------------------: |
-| **Raspberry Pi GCC Cross-Compiler Toolchains(Stretch)** | any x64/x86 Linux machine | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 6.3.0,  9.2.0, 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC Cross-Compiler Toolchains(Buster)** | any x64/x86 Linux machine | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 8.3.0, 9.2.0, 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC Native-Compiler Toolchains(Stretch)** | Raspbian Stretch OS (Debian Version 9) only | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC Native-Compiler Toolchains(Buster)** | Raspbian Buster OS (Debian Version 10) only | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC 64-Bit Cross-Compiler Toolchains** | any x64/x86 Linux machine | any x64 Raspberry Pi OS(like Pi64) | Stable/Production | 6.3.0, 8.3.0, 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC 64-Bit Native-Compiler Toolchains** | any x64 Raspberry Pi OS(like Pi64) | any x64 Raspbian OS(like Pi64) | Stable/Production | 8.3.0, 9.3.0, 10.1.0 |
-| **Exclusive/Experimental Toolchains** |  None | None | Beta/Experimental | None | 
+| **Raspberry Pi GCC Cross-Compiler Toolchains(Stretch)** | any x64/x86 Linux machine | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 6.3.0,  9.3.0, 10.2.0 |
+| **Raspberry Pi GCC Cross-Compiler Toolchains(Buster)** | any x64/x86 Linux machine | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 8.3.0, 9.3.0, 10.2.0 |
+| **Raspberry Pi GCC Native-Compiler Toolchains(Stretch)** | Raspbian Stretch OS (Debian Version 9) only | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 9.3.0, 10.2.0 |
+| **Raspberry Pi GCC Native-Compiler Toolchains(Buster)** | Raspbian Buster OS (Debian Version 10) only | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 9.3.0, 10.2.0 |
+| **Raspberry Pi GCC 64-Bit Cross-Compiler Toolchains** | any x64/x86 Linux machine | any x64 Raspberry Pi OS(like Pi64) | Stable/Production | 6.3.0, 8.3.0, 9.3.0, 10.2.0 |
+| **Raspberry Pi GCC 64-Bit Native-Compiler Toolchains** | any x64 Raspberry Pi OS(like Pi64) | any x64 Raspbian OS(like Pi64) | Stable/Production | 8.3.0, 9.3.0, 10.2.0 |
+| **Exclusive/Experimental Toolchains** |  x86/x86_64 Pi Desktop | x86/x86_64 Pi Desktop | Beta/Experimental | 10.2.0 | 
 
 **Tip:** _To get the location of each Binary of this project on SourceForge, you can also check out [this Reference Tree](https://github.com/abhiTronix/raspberry-pi-cross-compilers/wiki/Toolchain-Binaries-Reference-Tree#toolchain-binaries-reference-tree)._
 
@@ -216,9 +216,9 @@ Thank you,
 [pigz]:https://zlib.net/pigz/
 
 [cc-stretch-630]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Stretch/GCC%206.3.0/
-[cc-stretch-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Stretch/GCC%209.2.0/
+
 [cc-buster-830]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Buster/GCC%208.3.0/
-[cc-buster-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Buster/GCC%209.2.0/
+
 [nc-stretch-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Native-Compiler%20Toolchains/Stretch/
 [nc-buster-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Native-Compiler%20Toolchains/Buster/
 [cc-64-630]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Bonus%20Raspberry%20Pi%20GCC%2064-Bit%20Toolchains/Raspberry%20Pi%20GCC%2064-Bit%20Cross-Compiler%20Toolchains/GCC%206.3.0/

--- a/docs/native-gcc-buster.md
+++ b/docs/native-gcc-buster.md
@@ -72,13 +72,13 @@ This project now utilizes powerful [**Github Actions**][git-action] CI(Continuou
 
 | Toolchains | Host OS | Target OS | Current Status | Precompiled GCC versions available |
 | :---------- | :--------: | :-------: | :--------: | :------------------------: |
-| **Raspberry Pi GCC Cross-Compiler Toolchains(Stretch)** | any x64/x86 Linux machine | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 6.3.0,  9.2.0, 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC Cross-Compiler Toolchains(Buster)** | any x64/x86 Linux machine | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 8.3.0, 9.2.0, 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC Native-Compiler Toolchains(Stretch)** | Raspbian Stretch OS (Debian Version 9) only | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC Native-Compiler Toolchains(Buster)** | Raspbian Buster OS (Debian Version 10) only | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC 64-Bit Cross-Compiler Toolchains** | any x64/x86 Linux machine | any x64 Raspberry Pi OS(like Pi64) | Stable/Production | 6.3.0, 8.3.0, 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC 64-Bit Native-Compiler Toolchains** | any x64 Raspberry Pi OS(like Pi64) | any x64 Raspbian OS(like Pi64) | Stable/Production | 8.3.0, 9.3.0, 10.1.0 |
-| **Exclusive/Experimental Toolchains** |  None | None | Beta/Experimental | None | 
+| **Raspberry Pi GCC Cross-Compiler Toolchains(Stretch)** | any x64/x86 Linux machine | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 6.3.0,  9.3.0, 10.2.0 |
+| **Raspberry Pi GCC Cross-Compiler Toolchains(Buster)** | any x64/x86 Linux machine | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 8.3.0, 9.3.0, 10.2.0 |
+| **Raspberry Pi GCC Native-Compiler Toolchains(Stretch)** | Raspbian Stretch OS (Debian Version 9) only | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 9.3.0, 10.2.0 |
+| **Raspberry Pi GCC Native-Compiler Toolchains(Buster)** | Raspbian Buster OS (Debian Version 10) only | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 9.3.0, 10.2.0 |
+| **Raspberry Pi GCC 64-Bit Cross-Compiler Toolchains** | any x64/x86 Linux machine | any x64 Raspberry Pi OS(like Pi64) | Stable/Production | 6.3.0, 8.3.0, 9.3.0, 10.2.0 |
+| **Raspberry Pi GCC 64-Bit Native-Compiler Toolchains** | any x64 Raspberry Pi OS(like Pi64) | any x64 Raspbian OS(like Pi64) | Stable/Production | 8.3.0, 9.3.0, 10.2.0 |
+| **Exclusive/Experimental Toolchains** |  x86/x86_64 Pi Desktop | x86/x86_64 Pi Desktop | Beta/Experimental | 10.2.0 | 
 
 
 **Tip:** _To get the location of each Binary of this project on SourceForge, you can also check out [this Reference Tree](https://github.com/abhiTronix/raspberry-pi-cross-compilers/wiki/Toolchain-Binaries-Reference-Tree#toolchain-binaries-reference-tree)._
@@ -218,9 +218,9 @@ Thank you,
 [pigz]:https://zlib.net/pigz/
 
 [cc-stretch-630]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Stretch/GCC%206.3.0/
-[cc-stretch-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Stretch/GCC%209.2.0/
+
 [cc-buster-830]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Buster/GCC%208.3.0/
-[cc-buster-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Buster/GCC%209.2.0/
+
 [nc-stretch-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Native-Compiler%20Toolchains/Stretch/
 [nc-buster-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Native-Compiler%20Toolchains/Buster/
 [cc-64-630]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Bonus%20Raspberry%20Pi%20GCC%2064-Bit%20Toolchains/Raspberry%20Pi%20GCC%2064-Bit%20Cross-Compiler%20Toolchains/GCC%206.3.0/

--- a/docs/native-gcc-stretch.md
+++ b/docs/native-gcc-stretch.md
@@ -70,13 +70,13 @@ This project now utilizes powerful [**Github Actions**][git-action] CI(Continuou
 
 | Toolchains | Host OS | Target OS | Current Status | Precompiled GCC versions available |
 | :---------- | :--------: | :-------: | :--------: | :------------------------: |
-| **Raspberry Pi GCC Cross-Compiler Toolchains(Stretch)** | any x64/x86 Linux machine | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 6.3.0,  9.2.0, 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC Cross-Compiler Toolchains(Buster)** | any x64/x86 Linux machine | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 8.3.0, 9.2.0, 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC Native-Compiler Toolchains(Stretch)** | Raspbian Stretch OS (Debian Version 9) only | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC Native-Compiler Toolchains(Buster)** | Raspbian Buster OS (Debian Version 10) only | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC 64-Bit Cross-Compiler Toolchains** | any x64/x86 Linux machine | any x64 Raspberry Pi OS(like Pi64) | Stable/Production | 6.3.0, 8.3.0, 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC 64-Bit Native-Compiler Toolchains** | any x64 Raspberry Pi OS(like Pi64) | any x64 Raspbian OS(like Pi64) | Stable/Production | 8.3.0, 9.3.0, 10.1.0 |
-| **Exclusive/Experimental Toolchains** |  None | None | Beta/Experimental | None |  
+| **Raspberry Pi GCC Cross-Compiler Toolchains(Stretch)** | any x64/x86 Linux machine | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 6.3.0,  9.3.0, 10.2.0 |
+| **Raspberry Pi GCC Cross-Compiler Toolchains(Buster)** | any x64/x86 Linux machine | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 8.3.0, 9.3.0, 10.2.0 |
+| **Raspberry Pi GCC Native-Compiler Toolchains(Stretch)** | Raspbian Stretch OS (Debian Version 9) only | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 9.3.0, 10.2.0 |
+| **Raspberry Pi GCC Native-Compiler Toolchains(Buster)** | Raspbian Buster OS (Debian Version 10) only | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 9.3.0, 10.2.0 |
+| **Raspberry Pi GCC 64-Bit Cross-Compiler Toolchains** | any x64/x86 Linux machine | any x64 Raspberry Pi OS(like Pi64) | Stable/Production | 6.3.0, 8.3.0, 9.3.0, 10.2.0 |
+| **Raspberry Pi GCC 64-Bit Native-Compiler Toolchains** | any x64 Raspberry Pi OS(like Pi64) | any x64 Raspbian OS(like Pi64) | Stable/Production | 8.3.0, 9.3.0, 10.2.0 |
+| **Exclusive/Experimental Toolchains** |  x86/x86_64 Pi Desktop | x86/x86_64 Pi Desktop | Beta/Experimental | 10.2.0 |  
  
 
 
@@ -218,9 +218,9 @@ Thank you,
 [pigz]:https://zlib.net/pigz/
 
 [cc-stretch-630]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Stretch/GCC%206.3.0/
-[cc-stretch-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Stretch/GCC%209.2.0/
+
 [cc-buster-830]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Buster/GCC%208.3.0/
-[cc-buster-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Buster/GCC%209.2.0/
+
 [nc-stretch-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Native-Compiler%20Toolchains/Stretch/
 [nc-buster-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Native-Compiler%20Toolchains/Buster/
 [cc-64-630]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Bonus%20Raspberry%20Pi%20GCC%2064-Bit%20Toolchains/Raspberry%20Pi%20GCC%2064-Bit%20Cross-Compiler%20Toolchains/GCC%206.3.0/

--- a/docs/native-gcc.md
+++ b/docs/native-gcc.md
@@ -69,13 +69,13 @@ This project now utilizes powerful [**Github Actions**][git-action] CI(Continuou
 
 | Toolchains | Host OS | Target OS | Current Status | Precompiled GCC versions available |
 | :---------- | :--------: | :-------: | :--------: | :------------------------: |
-| **Raspberry Pi GCC Cross-Compiler Toolchains(Stretch)** | any x64/x86 Linux machine | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 6.3.0,  9.2.0, 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC Cross-Compiler Toolchains(Buster)** | any x64/x86 Linux machine | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 8.3.0, 9.2.0, 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC Native-Compiler Toolchains(Stretch)** | Raspbian Stretch OS (Debian Version 9) only | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC Native-Compiler Toolchains(Buster)** | Raspbian Buster OS (Debian Version 10) only | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC 64-Bit Cross-Compiler Toolchains** | any x64/x86 Linux machine | any x64 Raspberry Pi OS(like Pi64) | Stable/Production | 6.3.0, 8.3.0, 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC 64-Bit Native-Compiler Toolchains** | any x64 Raspberry Pi OS(like Pi64) | any x64 Raspbian OS(like Pi64) | Stable/Production | 8.3.0, 9.3.0, 10.1.0 |
-| **Exclusive/Experimental Toolchains** |  None | None | Beta/Experimental | None |  
+| **Raspberry Pi GCC Cross-Compiler Toolchains(Stretch)** | any x64/x86 Linux machine | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 6.3.0,  9.3.0, 10.2.0 |
+| **Raspberry Pi GCC Cross-Compiler Toolchains(Buster)** | any x64/x86 Linux machine | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 8.3.0, 9.3.0, 10.2.0 |
+| **Raspberry Pi GCC Native-Compiler Toolchains(Stretch)** | Raspbian Stretch OS (Debian Version 9) only | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 9.3.0, 10.2.0 |
+| **Raspberry Pi GCC Native-Compiler Toolchains(Buster)** | Raspbian Buster OS (Debian Version 10) only | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 9.3.0, 10.2.0 |
+| **Raspberry Pi GCC 64-Bit Cross-Compiler Toolchains** | any x64/x86 Linux machine | any x64 Raspberry Pi OS(like Pi64) | Stable/Production | 6.3.0, 8.3.0, 9.3.0, 10.2.0 |
+| **Raspberry Pi GCC 64-Bit Native-Compiler Toolchains** | any x64 Raspberry Pi OS(like Pi64) | any x64 Raspbian OS(like Pi64) | Stable/Production | 8.3.0, 9.3.0, 10.2.0 |
+| **Exclusive/Experimental Toolchains** |  x86/x86_64 Pi Desktop | x86/x86_64 Pi Desktop | Beta/Experimental | 10.2.0 |  
  
 
 
@@ -216,9 +216,9 @@ Thank you,
 [pigz]:https://zlib.net/pigz/
 
 [cc-stretch-630]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Stretch/GCC%206.3.0/
-[cc-stretch-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Stretch/GCC%209.2.0/
+
 [cc-buster-830]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Buster/GCC%208.3.0/
-[cc-buster-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Buster/GCC%209.2.0/
+
 [nc-stretch-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Native-Compiler%20Toolchains/Stretch/
 [nc-buster-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Native-Compiler%20Toolchains/Buster/
 [cc-64-630]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Bonus%20Raspberry%20Pi%20GCC%2064-Bit%20Toolchains/Raspberry%20Pi%20GCC%2064-Bit%20Cross-Compiler%20Toolchains/GCC%206.3.0/

--- a/docs/native-gcc64.md
+++ b/docs/native-gcc64.md
@@ -70,13 +70,13 @@ This project now utilizes powerful [**Github Actions**][git-action] CI(Continuou
 
 | Toolchains | Host OS | Target OS | Current Status | Precompiled GCC versions available |
 | :---------- | :--------: | :-------: | :--------: | :------------------------: |
-| **Raspberry Pi GCC Cross-Compiler Toolchains(Stretch)** | any x64/x86 Linux machine | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 6.3.0,  9.2.0, 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC Cross-Compiler Toolchains(Buster)** | any x64/x86 Linux machine | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 8.3.0, 9.2.0, 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC Native-Compiler Toolchains(Stretch)** | Raspbian Stretch OS (Debian Version 9) only | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC Native-Compiler Toolchains(Buster)** | Raspbian Buster OS (Debian Version 10) only | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC 64-Bit Cross-Compiler Toolchains** | any x64/x86 Linux machine | any x64 Raspberry Pi OS(like Pi64) | Stable/Production | 6.3.0, 8.3.0, 9.3.0, 10.1.0 |
-| **Raspberry Pi GCC 64-Bit Native-Compiler Toolchains** | any x64 Raspberry Pi OS(like Pi64) | any x64 Raspbian OS(like Pi64) | Stable/Production | 8.3.0, 9.3.0, 10.1.0 |
-| **Exclusive/Experimental Toolchains** |  None | None | Beta/Experimental | None | 
+| **Raspberry Pi GCC Cross-Compiler Toolchains(Stretch)** | any x64/x86 Linux machine | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 6.3.0,  9.3.0, 10.2.0 |
+| **Raspberry Pi GCC Cross-Compiler Toolchains(Buster)** | any x64/x86 Linux machine | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 8.3.0, 9.3.0, 10.2.0 |
+| **Raspberry Pi GCC Native-Compiler Toolchains(Stretch)** | Raspbian Stretch OS (Debian Version 9) only | Raspbian Stretch OS (Debian Version 9) only | Stable/Production | 9.3.0, 10.2.0 |
+| **Raspberry Pi GCC Native-Compiler Toolchains(Buster)** | Raspbian Buster OS (Debian Version 10) only | Raspbian Buster OS (Debian Version 10) only | Stable/Production | 9.3.0, 10.2.0 |
+| **Raspberry Pi GCC 64-Bit Cross-Compiler Toolchains** | any x64/x86 Linux machine | any x64 Raspberry Pi OS(like Pi64) | Stable/Production | 6.3.0, 8.3.0, 9.3.0, 10.2.0 |
+| **Raspberry Pi GCC 64-Bit Native-Compiler Toolchains** | any x64 Raspberry Pi OS(like Pi64) | any x64 Raspbian OS(like Pi64) | Stable/Production | 8.3.0, 9.3.0, 10.2.0 |
+| **Exclusive/Experimental Toolchains** |  x86/x86_64 Pi Desktop | x86/x86_64 Pi Desktop | Beta/Experimental | 10.2.0 | 
 
 
 **Tip:** _To get the location of each Binary of this project on SourceForge, you can also check out [this Reference Tree](https://github.com/abhiTronix/raspberry-pi-cross-compilers/wiki/Toolchain-Binaries-Reference-Tree#toolchain-binaries-reference-tree)._
@@ -217,9 +217,9 @@ Thank you,
 [pigz]:https://zlib.net/pigz/
 
 [cc-stretch-630]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Stretch/GCC%206.3.0/
-[cc-stretch-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Stretch/GCC%209.2.0/
+
 [cc-buster-830]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Buster/GCC%208.3.0/
-[cc-buster-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Buster/GCC%209.2.0/
+
 [nc-stretch-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Native-Compiler%20Toolchains/Stretch/
 [nc-buster-920]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Raspberry%20Pi%20GCC%20Native-Compiler%20Toolchains/Buster/
 [cc-64-630]:https://sourceforge.net/projects/raspberry-pi-cross-compilers/files/Bonus%20Raspberry%20Pi%20GCC%2064-Bit%20Toolchains/Raspberry%20Pi%20GCC%2064-Bit%20Cross-Compiler%20Toolchains/GCC%206.3.0/

--- a/patches/curl_stfp_patcher
+++ b/patches/curl_stfp_patcher
@@ -28,8 +28,8 @@
 
 sudo apt-get purge curl -y; 
 wget -q https://curl.haxx.se/download/curl-"$CURL_VERSION".tar.gz
-tar xf curl-7.68.0.tar.gz
-cd curl-7.68.0 || exit
+tar xf curl-"$CURL_VERSION".tar.gz
+cd curl-"$CURL_VERSION" || exit
 ./configure --with-libssh2
 make -s -j$(getconf _NPROCESSORS_ONLN)
 sudo -s make install

--- a/utils/SF_deployer
+++ b/utils/SF_deployer
@@ -108,3 +108,12 @@ if [ -f "$HOME/native-gcc-$GCC_VERSION-pi_$RPI_TYPE.tar.gz" ]; then
 		fi
 	fi
 fi
+
+if [ -f "$HOME/gcc-$GCC_VERSION-pi_$OS_TYPE.tar.gz" ]; then
+	FOLDER="Exclusive-Experimental Toolchains/Desktop/$OS_TYPE/GCC $GCC_VERSION"
+	if [ "$FOLDER" != "" ]; then
+		curl -k  "sftp://frs.sourceforge.net/home/pfs/project/raspberry-pi-cross-compilers/$FOLDER/" -u "$USER_SFTP":"$PASSWORD_SFTP" -T "$HOME/cross-gcc-$GCC_VERSION-pi_$RPI_TYPE.tar.gz" --ftp-create-dirs
+	else
+		exit 1
+	fi
+fi

--- a/utils/SF_docs_deployer
+++ b/utils/SF_docs_deployer
@@ -38,6 +38,9 @@ if [ -f "$HOME/root/README.md" ]; then
     if [ "$RPI_TYPE" = "64" ]; then
         FOLDER="Bonus Raspberry Pi GCC 64-Bit Toolchains"
         curl -k  "sftp://frs.sourceforge.net/home/pfs/project/raspberry-pi-cross-compilers/$FOLDER/" -u "$USER_SFTP":"$PASSWORD_SFTP" -T "$HOME/root/README.md" --ftp-create-dirs
+    elif [[ "$OS_TYPE" =~ ^("x86"|"x86_64")$ ]]; then
+        FOLDER="Exclusive-Experimental Toolchains/Desktop"
+        curl -k  "sftp://frs.sourceforge.net/home/pfs/project/raspberry-pi-cross-compilers/$FOLDER/" -u "$USER_SFTP":"$PASSWORD_SFTP" -T "$HOME/root/README.md" --ftp-create-dirs
     else
         if [ "$COMPILER_TYPE" = "CROSS" ]; then
             FOLDER="Raspberry Pi GCC Cross-Compiler Toolchains"
@@ -88,5 +91,10 @@ elif [ "$COMPILER_TYPE" = "NATIVE" ]; then
         fi
     fi
 else
-    exit 1
+    if [[ "$OS_TYPE" =~ ^("x86"|"x86_64")$ ]]; then
+        FOLDER="Exclusive-Experimental Toolchains/Desktop/$OS_TYPE"
+        curl -k  "sftp://frs.sourceforge.net/home/pfs/project/raspberry-pi-cross-compilers/$FOLDER/" -u "$USER_SFTP":"$PASSWORD_SFTP" -T "$HOME/README.md" --ftp-create-dirs
+    else
+        exit 0
+    fi
 fi


### PR DESCRIPTION
### Description

Release next Major Stable release with lots of new and exciting features.

### Changes

* **Initial support for Raspberry Pi Desktop toolchains**
  - Added `x86_64TB` CI build script.
  - Added support x86 & x86_64 Raspberry Pi Desktop OS types.
  - Added Github Action workflow for these toolchains.
  - Updated SF_deployer and SF_docs_deployer to include these new changes.
  - Updated README.md and added new docs.
  - Updated `curl` to latest v7.72.0
- **Complete migration to latest GCC 10.2.0 and GDB 9.2. (Fixed #51)**
  - Replaced GCC version `10.1.0` with latest `10.2.0` build matrix. 
  - Updated GDB to latest `9.2`.
  - Removed obselete `9.2.0` from build matrix.
  - Removed obselete versions from Docs.
- Reduced x86/86_64 Pi Desktop builds to GCC v10.2.0 only.
- Fixed wrong bash-script in x86 envs.
- Fixed `-march` wrong value on x86_64 machines.
- Different env variables for handling arch names.
- Changed target to more generic `*-pc-linux-gnu.`
- Changed linux source download URL & fixed ARCH bug.
- Reimplemented `x86_64TB` CI build-script from scratch.
- Fixed undefined patcher bugs.
- Updated Docs with changes.
- Fixed Typos

### Related Issues

#49